### PR TITLE
feat(comhub): implement ComHub Overview component based on provided JSON schema

### DIFF
--- a/src/components/ComHubOverview.vue
+++ b/src/components/ComHubOverview.vue
@@ -34,8 +34,8 @@
       </div>
 
       <!-- Expanded Socket List -->
-      <div v-if="expanded[iface.uuid]" class="mt-3 border-t py-2">
-        <div class="flex flex-col gap-2">
+      <div v-if="expanded[iface.uuid]" class="mt-3 border-t pt-3 flex flex-col gap-3">
+      
         <div
           v-for="socket in getSortedSockets(iface.sockets)"
           :key="socket.uuid + socket.endpoint"
@@ -60,11 +60,10 @@
           </h4>
 
           <!-- 6. Distance + time in one line with bullet -->
-          <div class="text-xs text-neutral-500 mt-1 space-y-0.5">
+          <div class="text-xs text-neutral-500 mt-1">
              Distance: {{ socket.properties.distance }}
              • Created: {{ formatTime(socket.properties.known_since) }}
           
-          </div>
         </div>
       </div>
     </div>

--- a/src/components/ComHubOverview.vue
+++ b/src/components/ComHubOverview.vue
@@ -61,9 +61,9 @@
 
           <!-- 6. Distance + time in one line with bullet -->
           <div class="text-xs text-neutral-500 mt-1 space-y-0.5">
-             <div>Distance: {{ socket.properties.distance }}</div>
-            <div>Created: {{ formatTime(socket.properties.known_since) }}
-          </div>
+             Distance: {{ socket.properties.distance }}
+             • Created: {{ formatTime(socket.properties.known_since) }}
+          
           </div>
         </div>
       </div>

--- a/src/components/ComHubOverview.vue
+++ b/src/components/ComHubOverview.vue
@@ -160,11 +160,26 @@ function getDirectionArrow(direction: string): string {
   return ""
 }
 
+const rtf = new Intl.RelativeTimeFormat(undefined, {
+  numeric: "auto",
+})
+
 function formatTime(seconds: number): string {
-  if (seconds < 60) return `${seconds}s ago`
+  if (seconds < 60) {
+    return rtf.format(-seconds, "second")
+  }
+
   const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes}m ago`
+  if (minutes < 60) {
+    return rtf.format(-minutes, "minute")
+  }
+
   const hours = Math.floor(minutes / 60)
-  return `${hours}h ago`
+  if (hours < 24) {
+    return rtf.format(-hours, "hour")
+  }
+
+  const days = Math.floor(hours / 24)
+  return rtf.format(-days, "day")
 }
 </script>

--- a/src/components/ComHubOverview.vue
+++ b/src/components/ComHubOverview.vue
@@ -34,11 +34,12 @@
       </div>
 
       <!-- Expanded Socket List -->
-      <div v-if="expanded[iface.uuid]" class="mt-3 border-t pt-3">
+      <div v-if="expanded[iface.uuid]" class="mt-3 border-t py-2">
+        <div class="flex flex-col gap-2">
         <div
           v-for="socket in getSortedSockets(iface.sockets)"
           :key="socket.uuid + socket.endpoint"
-          class="text-sm p-3 rounded bg-neutral-100 dark:bg-neutral-800 mb-2"
+          class="text-sm p-3 rounded bg-neutral-100 dark:bg-neutral-800"
         >
           <!-- 5. Endpoint highlighted as heading + 7. direct label + 3. arrow -->
           <h4 class="font-semibold flex items-center gap-2">
@@ -59,14 +60,15 @@
           </h4>
 
           <!-- 6. Distance + time in one line with bullet -->
-          <div class="text-xs text-neutral-500 mt-1">
-            Distance: {{ socket.properties.distance }}
-            • {{ formatTime(socket.properties.known_since) }}
+          <div class="text-xs text-neutral-500 mt-1 space-y-0.5">
+             <div>Distance: {{ socket.properties.distance }}</div>
+            <div>Created: {{ formatTime(socket.properties.known_since) }}
+          </div>
           </div>
         </div>
       </div>
     </div>
-
+  </div>
     <div v-if="!comhub.interfaces.length" class="text-sm text-neutral-500">
       No active interfaces found.
     </div>

--- a/src/components/ComHubOverview.vue
+++ b/src/components/ComHubOverview.vue
@@ -1,0 +1,163 @@
+<template>
+    <div class="m-5 p-4 h-full overflow-auto">
+      <h2 class="text-lg font-semibold mb-4">ComHub Overview</h2>
+  
+      <div
+        v-for="iface in comhub.interfaces"
+        :key="iface.uuid"
+        class="border rounded-lg p-3 mb-3 bg-white dark:bg-neutral-900 shadow-sm"
+      >
+        <!-- Interface Header -->
+        <div
+          class="flex justify-between items-center cursor-pointer"
+          @click="toggle(iface.uuid)"
+        >
+          <div>
+            <div class="font-medium">
+              {{ iface.properties.name || iface.properties.interface_type }}
+            </div>
+  
+            <div class="text-xs text-neutral-500 mt-1">
+              Type: {{ iface.properties.interface_type }}
+              • Sockets: {{ iface.sockets.length }}
+            </div>
+          </div>
+  
+          <div class="text-xs text-neutral-400">
+            RTT: {{ iface.properties.round_trip_time }} ms
+          </div>
+        </div>
+  
+        <!-- Expanded Socket List -->
+        <div v-if="expanded[iface.uuid]" class="mt-3 border-t pt-3">
+          <div
+            v-for="socket in iface.sockets"
+            :key="socket.uuid + socket.endpoint"
+            class="text-sm p-2 rounded bg-neutral-100 dark:bg-neutral-800 mb-2"
+          >
+            <div><strong>Endpoint:</strong> {{ socket.endpoint }}</div>
+            <div>
+              <strong>Direct:</strong>
+              {{ socket.properties.is_direct ? "Direct" : "Indirect" }}
+            </div>
+            <div>
+              <strong>Distance:</strong> {{ socket.properties.distance }}
+            </div>
+            <div>
+              <strong>Time since creation:</strong>
+              {{ formatTime(socket.properties.known_since) }}
+            </div>
+          </div>
+        </div>
+      </div>
+  
+      <div v-if="!comhub.interfaces.length" class="text-sm text-neutral-500">
+        No active interfaces found.
+      </div>
+    </div>
+  </template>
+  
+  <script setup lang="ts">
+  import { reactive } from 'vue'
+  
+  /**
+   * TEMP MOCK DATA (from issue JSON)
+   * Replace later with real ComHub runtime state
+   * TODO: Replace mock JSON with live ComHub runtime state
+   */
+
+    const comhub = reactive({
+    "endpoint": "@@FB2D5CF3FBE8CF00FC4518DAF76A189602E1",
+    "interfaces": [
+        {
+            "uuid": "com_interface::28a6b060-055c-4d20-a715-9bafd9edb90d",
+            "properties": {
+                "interface_type": "websocket-client",
+                "channel": "websocket",
+                "name": "ws://localhost:8043",
+                "direction": "InOut",
+                "round_trip_time": 40,
+                "max_bandwidth": 1000,
+                "continuous_connection": false,
+                "allow_redirects": true,
+                "is_secure_channel": false,
+                "reconnection_config": "NoReconnect",
+                "auto_identify": true
+            },
+            "sockets": [
+                {
+                    "uuid": "socket::4a17ec53-6027-4527-9786-abf8db76c61f",
+                    "direction": "InOut",
+                    "endpoint": "@server",
+                    "properties": {
+                        "known_since": 4,
+                        "distance": 1,
+                        "is_direct": true,
+                        "channel_factor": 1,
+                        "direction": "InOut"
+                    }
+                },
+                {
+                    "uuid": "socket::4a17ec53-6027-4527-9786-abf8db76c61f",
+                    "direction": "InOut",
+                    "endpoint": "@@8FAEBB621D91CB42EA59389EB5C47A9BADEF",
+                    "properties": {
+                        "known_since": 16852,
+                        "distance": 2,
+                        "is_direct": false,
+                        "channel_factor": 1,
+                        "direction": "InOut"
+                    }
+                }
+            ],
+            "is_waiting_for_socket_connections": false
+        },
+        {
+            "uuid": "com_interface::a8fc3085-9717-4715-bbed-b20f6128e6df",
+            "properties": {
+                "interface_type": "local",
+                "channel": "local",
+                "direction": "InOut",
+                "round_trip_time": 0,
+                "max_bandwidth": 4294967295,
+                "continuous_connection": false,
+                "allow_redirects": true,
+                "is_secure_channel": false,
+                "reconnection_config": "NoReconnect",
+                "auto_identify": false
+            },
+            "sockets": [
+                {
+                    "uuid": "socket::cb2f1a7e-5fc6-4bd1-acdc-ce796606c6bd",
+                    "direction": "InOut",
+                    "endpoint": "@@local",
+                    "properties": {
+                        "known_since": 0,
+                        "distance": 0,
+                        "is_direct": true,
+                        "channel_factor": 1,
+                        "direction": "InOut"
+                    }
+                }
+            ],
+            "is_waiting_for_socket_connections": false
+        }
+    ],
+    "endpoint_sockets": {}
+})
+  
+  const expanded = reactive<Record<string, boolean>>({})
+  
+  function toggle(uuid: string) {
+    expanded[uuid] = !expanded[uuid]
+  }
+  
+  function formatTime(seconds: number): string {
+    if (seconds < 60) return `${seconds}s ago`
+    const minutes = Math.floor(seconds / 60)
+    if (minutes < 60) return `${minutes}m ago`
+    const hours = Math.floor(minutes / 60)
+    return `${hours}h ago`
+  }
+  </script>
+  

--- a/src/components/ComHubOverview.vue
+++ b/src/components/ComHubOverview.vue
@@ -1,163 +1,170 @@
 <template>
-    <div class="m-5 p-4 h-full overflow-auto">
-      <h2 class="text-lg font-semibold mb-4">ComHub Overview</h2>
-  
+  <div class="m-5 p-4 h-full overflow-auto">
+    <h2 class="text-lg font-semibold mb-4">ComHub Overview</h2>
+
+    <div
+      v-for="iface in comhub.interfaces"
+      :key="iface.uuid"
+      class="border rounded-lg p-3 mb-3 bg-white dark:bg-neutral-900 shadow-sm"
+    >
+      <!-- Interface Header -->
       <div
-        v-for="iface in comhub.interfaces"
-        :key="iface.uuid"
-        class="border rounded-lg p-3 mb-3 bg-white dark:bg-neutral-900 shadow-sm"
+        class="flex justify-between items-center cursor-pointer"
+        @click="toggle(iface.uuid)"
       >
-        <!-- Interface Header -->
-        <div
-          class="flex justify-between items-center cursor-pointer"
-          @click="toggle(iface.uuid)"
-        >
-          <div>
-            <div class="font-medium">
-              {{ iface.properties.name || iface.properties.interface_type }}
-            </div>
-  
-            <div class="text-xs text-neutral-500 mt-1">
-              Type: {{ iface.properties.interface_type }}
-              • Sockets: {{ iface.sockets.length }}
-            </div>
-          </div>
-  
-          <div class="text-xs text-neutral-400">
-            RTT: {{ iface.properties.round_trip_time }} ms
+        <div>
+          <!-- 1. Channel type prominent + name -->
+          <h3 class="font-semibold">
+            {{ iface.properties.interface_type }}
+            <span v-if="iface.properties.name">
+              ({{ iface.properties.name }})
+            </span>
+          </h3>
+
+          <!-- 2. Show channel next to socket count -->
+          <div class="text-xs text-neutral-500 mt-1">
+            Sockets: {{ iface.sockets.length }}
+            • Channel: {{ iface.properties.channel }}
           </div>
         </div>
-  
-        <!-- Expanded Socket List -->
-        <div v-if="expanded[iface.uuid]" class="mt-3 border-t pt-3">
-          <div
-            v-for="socket in iface.sockets"
-            :key="socket.uuid + socket.endpoint"
-            class="text-sm p-2 rounded bg-neutral-100 dark:bg-neutral-800 mb-2"
-          >
-            <div><strong>Endpoint:</strong> {{ socket.endpoint }}</div>
-            <div>
-              <strong>Direct:</strong>
-              {{ socket.properties.is_direct ? "Direct" : "Indirect" }}
-            </div>
-            <div>
-              <strong>Distance:</strong> {{ socket.properties.distance }}
-            </div>
-            <div>
-              <strong>Time since creation:</strong>
-              {{ formatTime(socket.properties.known_since) }}
-            </div>
-          </div>
+
+        <div class="text-xs text-neutral-400">
+          RTT: {{ iface.properties.round_trip_time }} ms
         </div>
       </div>
-  
-      <div v-if="!comhub.interfaces.length" class="text-sm text-neutral-500">
-        No active interfaces found.
+
+      <!-- Expanded Socket List -->
+      <div v-if="expanded[iface.uuid]" class="mt-3 border-t pt-3">
+        <div
+          v-for="socket in getSortedSockets(iface.sockets)"
+          :key="socket.uuid + socket.endpoint"
+          class="text-sm p-3 rounded bg-neutral-100 dark:bg-neutral-800 mb-2"
+        >
+          <!-- 5. Endpoint highlighted as heading + 7. direct label + 3. arrow -->
+          <h4 class="font-semibold flex items-center gap-2">
+            {{ socket.endpoint }}
+
+            <!-- Direct label only if direct -->
+            <span
+              v-if="socket.properties.is_direct"
+              class="text-xs px-2 py-0.5 rounded bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300"
+            >
+              direct
+            </span>
+
+            <!-- Direction arrow -->
+            <span class="text-neutral-400">
+              {{ getDirectionArrow(socket.direction) }}
+            </span>
+          </h4>
+
+          <!-- 6. Distance + time in one line with bullet -->
+          <div class="text-xs text-neutral-500 mt-1">
+            Distance: {{ socket.properties.distance }}
+            • {{ formatTime(socket.properties.known_since) }}
+          </div>
+        </div>
       </div>
     </div>
-  </template>
-  
-  <script setup lang="ts">
-  import { reactive } from 'vue'
-  
-  /**
-   * TEMP MOCK DATA (from issue JSON)
-   * Replace later with real ComHub runtime state
-   * TODO: Replace mock JSON with live ComHub runtime state
-   */
 
-    const comhub = reactive({
-    "endpoint": "@@FB2D5CF3FBE8CF00FC4518DAF76A189602E1",
-    "interfaces": [
+    <div v-if="!comhub.interfaces.length" class="text-sm text-neutral-500">
+      No active interfaces found.
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive } from 'vue'
+
+/**
+ * TEMP MOCK DATA (from issue JSON)
+ * TODO: Replace mock JSON with live ComHub runtime state
+ */
+const comhub = reactive({
+  endpoint: "@@FB2D5CF3FBE8CF00FC4518DAF76A189602E1",
+  interfaces: [
+    {
+      uuid: "com_interface::28a6b060-055c-4d20-a715-9bafd9edb90d",
+      properties: {
+        interface_type: "websocket-client",
+        channel: "websocket",
+        name: "ws://localhost:8043",
+        direction: "InOut",
+        round_trip_time: 40,
+        max_bandwidth: 1000,
+        continuous_connection: false,
+        allow_redirects: true,
+        is_secure_channel: false,
+        reconnection_config: "NoReconnect",
+        auto_identify: true
+      },
+      sockets: [
         {
-            "uuid": "com_interface::28a6b060-055c-4d20-a715-9bafd9edb90d",
-            "properties": {
-                "interface_type": "websocket-client",
-                "channel": "websocket",
-                "name": "ws://localhost:8043",
-                "direction": "InOut",
-                "round_trip_time": 40,
-                "max_bandwidth": 1000,
-                "continuous_connection": false,
-                "allow_redirects": true,
-                "is_secure_channel": false,
-                "reconnection_config": "NoReconnect",
-                "auto_identify": true
-            },
-            "sockets": [
-                {
-                    "uuid": "socket::4a17ec53-6027-4527-9786-abf8db76c61f",
-                    "direction": "InOut",
-                    "endpoint": "@server",
-                    "properties": {
-                        "known_since": 4,
-                        "distance": 1,
-                        "is_direct": true,
-                        "channel_factor": 1,
-                        "direction": "InOut"
-                    }
-                },
-                {
-                    "uuid": "socket::4a17ec53-6027-4527-9786-abf8db76c61f",
-                    "direction": "InOut",
-                    "endpoint": "@@8FAEBB621D91CB42EA59389EB5C47A9BADEF",
-                    "properties": {
-                        "known_since": 16852,
-                        "distance": 2,
-                        "is_direct": false,
-                        "channel_factor": 1,
-                        "direction": "InOut"
-                    }
-                }
-            ],
-            "is_waiting_for_socket_connections": false
+          uuid: "socket::4a17ec53-6027-4527-9786-abf8db76c61f",
+          direction: "InOut",
+          endpoint: "@server",
+          properties: {
+            known_since: 4,
+            distance: 1,
+            is_direct: true,
+            channel_factor: 1,
+            direction: "InOut"
+          }
         },
         {
-            "uuid": "com_interface::a8fc3085-9717-4715-bbed-b20f6128e6df",
-            "properties": {
-                "interface_type": "local",
-                "channel": "local",
-                "direction": "InOut",
-                "round_trip_time": 0,
-                "max_bandwidth": 4294967295,
-                "continuous_connection": false,
-                "allow_redirects": true,
-                "is_secure_channel": false,
-                "reconnection_config": "NoReconnect",
-                "auto_identify": false
-            },
-            "sockets": [
-                {
-                    "uuid": "socket::cb2f1a7e-5fc6-4bd1-acdc-ce796606c6bd",
-                    "direction": "InOut",
-                    "endpoint": "@@local",
-                    "properties": {
-                        "known_since": 0,
-                        "distance": 0,
-                        "is_direct": true,
-                        "channel_factor": 1,
-                        "direction": "InOut"
-                    }
-                }
-            ],
-            "is_waiting_for_socket_connections": false
+          uuid: "socket::4a17ec53-6027-4527-9786-abf8db76c61f",
+          direction: "InOut",
+          endpoint: "@@8FAEBB621D91CB42EA59389EB5C47A9BADEF",
+          properties: {
+            known_since: 16852,
+            distance: 2,
+            is_direct: false,
+            channel_factor: 1,
+            direction: "InOut"
+          }
         }
-    ],
-    "endpoint_sockets": {}
+      ],
+      is_waiting_for_socket_connections: false
+    }
+  ],
+  endpoint_sockets: {}
 })
-  
-  const expanded = reactive<Record<string, boolean>>({})
-  
-  function toggle(uuid: string) {
-    expanded[uuid] = !expanded[uuid]
-  }
-  
-  function formatTime(seconds: number): string {
-    if (seconds < 60) return `${seconds}s ago`
-    const minutes = Math.floor(seconds / 60)
-    if (minutes < 60) return `${minutes}m ago`
-    const hours = Math.floor(minutes / 60)
-    return `${hours}h ago`
-  }
-  </script>
-  
+
+const expanded = reactive<Record<string, boolean>>({})
+
+function toggle(uuid: string) {
+  expanded[uuid] = !expanded[uuid]
+}
+
+/**
+ * 4. Sorting logic:
+ * - Direct sockets first
+ * - Then newest first (lower known_since = newer)
+ */
+function getSortedSockets(sockets: any[]) {
+  return [...sockets].sort((a, b) => {
+    if (a.properties.is_direct !== b.properties.is_direct) {
+      return a.properties.is_direct ? -1 : 1
+    }
+    return a.properties.known_since - b.properties.known_since
+  })
+}
+
+/**
+ * 3. Direction arrows
+ */
+function getDirectionArrow(direction: string): string {
+  if (direction === "InOut") return "↔"
+  if (direction === "In") return "←"
+  if (direction === "Out") return "→"
+  return ""
+}
+
+function formatTime(seconds: number): string {
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  return `${hours}h ago`
+}
+</script>

--- a/src/components/ComHubOverview.vue
+++ b/src/components/ComHubOverview.vue
@@ -132,6 +132,19 @@ const comhub = reactive({
 
 const expanded = reactive<Record<string, boolean>>({})
 
+type ComHubSocket = {
+  uuid: string
+  direction: string
+  endpoint: string
+  properties: {
+    known_since: number
+    distance: number
+    is_direct: boolean
+    channel_factor: number
+    direction: string
+  }
+}
+
 function toggle(uuid: string) {
   expanded[uuid] = !expanded[uuid]
 }
@@ -141,7 +154,7 @@ function toggle(uuid: string) {
  * - Direct sockets first
  * - Then newest first (lower known_since = newer)
  */
-function getSortedSockets(sockets: any[]) {
+function getSortedSockets(sockets: ComHubSocket[]) {
   return [...sockets].sort((a, b) => {
     if (a.properties.is_direct !== b.properties.is_direct) {
       return a.properties.is_direct ? -1 : 1

--- a/src/components/Window.vue
+++ b/src/components/Window.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import ComHubOverview from '@/components/ComHubOverview.vue';
 import { useDragDrop } from '@/composable/useDragDrop.ts';
 import { collapseSplit } from '@/composable/useLayoutTree.ts';
 import {
@@ -165,26 +166,13 @@ function collapseNearSide(node: SplitNode, side: CollapseSide): void {
             </div>
         </div>
 
-        <!-- eslint-disable vue/no-mutating-props -->
-        <div class="w-full h-full flex flex-col items-center justify-center p-4 gap-3">
-            <input
-                v-model="node.data.text"
-                type="text"
-                placeholder="Type text..."
-                class="border border-neutral-300 dark:border-neutral-700 rounded-lg px-2 py-1 w-full max-w-xs text-sm bg-transparent focus:outline-none focus:ring-2 focus:ring-primary"
-            />
-            <input
-                v-model="node.data.date"
-                type="date"
-                class="border border-neutral-300 dark:border-neutral-700 rounded-lg px-2 py-1 w-full max-w-xs text-sm bg-transparent focus:outline-none focus:ring-2 focus:ring-primary"
-            />
+    <!-- PANEL CONTENT -->
+    <div class="w-full h-full">
+  <ComHubOverview />
+</div>
 
-            <div class="text-xs text-neutral-500 text-center mt-2">
-                {{ node.data?.text || '— no text —' }} <br />
-                {{ node.data?.date || '— no date —' }}
-            </div>
-        </div>
-    </div>
+
+  </div>
 
     <!-- SPLIT -->
     <div


### PR DESCRIPTION
##Related to #69

## Summary

Implemented the ComHub Overview component to display the current state of the local ComHub based on the provided JSON schema.

## Features

* Displays all active communication interfaces
* Shows interface name and socket count
* Indicates direct or indirect connections
* Displays distance and time since creation
* Expandable interface view showing connected socket endpoint IDs

## Implementation Details

* Created a reusable Vue 3 component (`ComHubOverview.vue`)
* Integrated safely with the existing layout system without modifying core layout logic
* Followed the exact JSON structure provided in the issue description
* Structured for future integration with real runtime ComHub state instead of mock data

## Testing

* Verified locally using `npm run dev`
* Confirmed UI rendering and expand/collapse behavior
