### PR TITLE
feat(ComHubOverview): add endpoint search with interface-level filtering

### DIFF
--- a/src/components/ComHubOverview.vue
+++ b/src/components/ComHubOverview.vue
@@ -34,8 +34,8 @@
       </div>
 
       <!-- Expanded Socket List -->
-      <div v-if="expanded[iface.uuid]" class="mt-3 border-t py-2">
-        <div class="flex flex-col gap-2">
+      <div v-if="expanded[iface.uuid]" class="mt-3 border-t pt-3 flex flex-col gap-3">
+      
         <div
           v-for="socket in getSortedSockets(iface.sockets)"
           :key="socket.uuid + socket.endpoint"
@@ -60,11 +60,10 @@
           </h4>
 
           <!-- 6. Distance + time in one line with bullet -->
-          <div class="text-xs text-neutral-500 mt-1 space-y-0.5">
+          <div class="text-xs text-neutral-500 mt-1">
              Distance: {{ socket.properties.distance }}
              • Created: {{ formatTime(socket.properties.known_since) }}
           
-          </div>
         </div>
       </div>
     </div>

--- a/src/components/ComHubOverview.vue
+++ b/src/components/ComHubOverview.vue
@@ -61,9 +61,9 @@
 
           <!-- 6. Distance + time in one line with bullet -->
           <div class="text-xs text-neutral-500 mt-1 space-y-0.5">
-             <div>Distance: {{ socket.properties.distance }}</div>
-            <div>Created: {{ formatTime(socket.properties.known_since) }}
-          </div>
+             Distance: {{ socket.properties.distance }}
+             • Created: {{ formatTime(socket.properties.known_since) }}
+          
           </div>
         </div>
       </div>

--- a/src/components/ComHubOverview.vue
+++ b/src/components/ComHubOverview.vue
@@ -1,199 +1,163 @@
 <template>
-  <div class="m-5 p-4 h-full overflow-auto">
-    <h2 class="text-lg font-semibold mb-4">ComHub Overview</h2>
-
-    <div
-      v-for="iface in comhub.interfaces"
-      :key="iface.uuid"
-      class="border rounded-lg p-3 mb-3 bg-white dark:bg-neutral-900 shadow-sm"
-    >
-      <!-- Interface Header -->
+    <div class="m-5 p-4 h-full overflow-auto">
+      <h2 class="text-lg font-semibold mb-4">ComHub Overview</h2>
+  
       <div
-        class="flex justify-between items-center cursor-pointer"
-        @click="toggle(iface.uuid)"
+        v-for="iface in comhub.interfaces"
+        :key="iface.uuid"
+        class="border rounded-lg p-3 mb-3 bg-white dark:bg-neutral-900 shadow-sm"
       >
-        <div>
-          <!-- 1. Channel type prominent + name -->
-          <h3 class="font-semibold">
-            {{ iface.properties.interface_type }}
-            <span v-if="iface.properties.name">
-              ({{ iface.properties.name }})
-            </span>
-          </h3>
-
-          <!-- 2. Show channel next to socket count -->
-          <div class="text-xs text-neutral-500 mt-1">
-            Sockets: {{ iface.sockets.length }}
-            • Channel: {{ iface.properties.channel }}
+        <!-- Interface Header -->
+        <div
+          class="flex justify-between items-center cursor-pointer"
+          @click="toggle(iface.uuid)"
+        >
+          <div>
+            <div class="font-medium">
+              {{ iface.properties.name || iface.properties.interface_type }}
+            </div>
+  
+            <div class="text-xs text-neutral-500 mt-1">
+              Type: {{ iface.properties.interface_type }}
+              • Sockets: {{ iface.sockets.length }}
+            </div>
+          </div>
+  
+          <div class="text-xs text-neutral-400">
+            RTT: {{ iface.properties.round_trip_time }} ms
           </div>
         </div>
-
-        <div class="text-xs text-neutral-400">
-          RTT: {{ iface.properties.round_trip_time }} ms
+  
+        <!-- Expanded Socket List -->
+        <div v-if="expanded[iface.uuid]" class="mt-3 border-t pt-3">
+          <div
+            v-for="socket in iface.sockets"
+            :key="socket.uuid + socket.endpoint"
+            class="text-sm p-2 rounded bg-neutral-100 dark:bg-neutral-800 mb-2"
+          >
+            <div><strong>Endpoint:</strong> {{ socket.endpoint }}</div>
+            <div>
+              <strong>Direct:</strong>
+              {{ socket.properties.is_direct ? "Direct" : "Indirect" }}
+            </div>
+            <div>
+              <strong>Distance:</strong> {{ socket.properties.distance }}
+            </div>
+            <div>
+              <strong>Time since creation:</strong>
+              {{ formatTime(socket.properties.known_since) }}
+            </div>
+          </div>
         </div>
       </div>
-
-      <!-- Expanded Socket List -->
-      <div v-if="expanded[iface.uuid]" class="mt-3 border-t pt-3 flex flex-col gap-3">
-      
-        <div
-          v-for="socket in getSortedSockets(iface.sockets)"
-          :key="socket.uuid + socket.endpoint"
-          class="text-sm p-3 rounded bg-neutral-100 dark:bg-neutral-800"
-        >
-          <!-- 5. Endpoint highlighted as heading + 7. direct label + 3. arrow -->
-          <h4 class="font-semibold flex items-center gap-2">
-            {{ socket.endpoint }}
-
-            <!-- Direct label only if direct -->
-            <span
-              v-if="socket.properties.is_direct"
-              class="text-xs px-2 py-0.5 rounded bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300"
-            >
-              direct
-            </span>
-
-            <!-- Direction arrow -->
-            <span class="text-neutral-400">
-              {{ getDirectionArrow(socket.direction) }}
-            </span>
-          </h4>
-
-          <!-- 6. Distance + time in one line with bullet -->
-          <div class="text-xs text-neutral-500 mt-1">
-             Distance: {{ socket.properties.distance }}
-             • Created: {{ formatTime(socket.properties.known_since) }}
-          
-        </div>
+  
+      <div v-if="!comhub.interfaces.length" class="text-sm text-neutral-500">
+        No active interfaces found.
       </div>
     </div>
-  </div>
-    <div v-if="!comhub.interfaces.length" class="text-sm text-neutral-500">
-      No active interfaces found.
-    </div>
-  </div>
-</template>
+  </template>
+  
+  <script setup lang="ts">
+  import { reactive } from 'vue'
+  
+  /**
+   * TEMP MOCK DATA (from issue JSON)
+   * Replace later with real ComHub runtime state
+   * TODO: Replace mock JSON with live ComHub runtime state
+   */
 
-<script setup lang="ts">
-import { reactive } from 'vue'
-
-/**
- * TEMP MOCK DATA (from issue JSON)
- * TODO: Replace mock JSON with live ComHub runtime state
- */
-const comhub = reactive({
-  endpoint: "@@FB2D5CF3FBE8CF00FC4518DAF76A189602E1",
-  interfaces: [
-    {
-      uuid: "com_interface::28a6b060-055c-4d20-a715-9bafd9edb90d",
-      properties: {
-        interface_type: "websocket-client",
-        channel: "websocket",
-        name: "ws://localhost:8043",
-        direction: "InOut",
-        round_trip_time: 40,
-        max_bandwidth: 1000,
-        continuous_connection: false,
-        allow_redirects: true,
-        is_secure_channel: false,
-        reconnection_config: "NoReconnect",
-        auto_identify: true
-      },
-      sockets: [
+    const comhub = reactive({
+    "endpoint": "@@FB2D5CF3FBE8CF00FC4518DAF76A189602E1",
+    "interfaces": [
         {
-          uuid: "socket::4a17ec53-6027-4527-9786-abf8db76c61f",
-          direction: "InOut",
-          endpoint: "@server",
-          properties: {
-            known_since: 4,
-            distance: 1,
-            is_direct: true,
-            channel_factor: 1,
-            direction: "InOut"
-          }
+            "uuid": "com_interface::28a6b060-055c-4d20-a715-9bafd9edb90d",
+            "properties": {
+                "interface_type": "websocket-client",
+                "channel": "websocket",
+                "name": "ws://localhost:8043",
+                "direction": "InOut",
+                "round_trip_time": 40,
+                "max_bandwidth": 1000,
+                "continuous_connection": false,
+                "allow_redirects": true,
+                "is_secure_channel": false,
+                "reconnection_config": "NoReconnect",
+                "auto_identify": true
+            },
+            "sockets": [
+                {
+                    "uuid": "socket::4a17ec53-6027-4527-9786-abf8db76c61f",
+                    "direction": "InOut",
+                    "endpoint": "@server",
+                    "properties": {
+                        "known_since": 4,
+                        "distance": 1,
+                        "is_direct": true,
+                        "channel_factor": 1,
+                        "direction": "InOut"
+                    }
+                },
+                {
+                    "uuid": "socket::4a17ec53-6027-4527-9786-abf8db76c61f",
+                    "direction": "InOut",
+                    "endpoint": "@@8FAEBB621D91CB42EA59389EB5C47A9BADEF",
+                    "properties": {
+                        "known_since": 16852,
+                        "distance": 2,
+                        "is_direct": false,
+                        "channel_factor": 1,
+                        "direction": "InOut"
+                    }
+                }
+            ],
+            "is_waiting_for_socket_connections": false
         },
         {
-          uuid: "socket::4a17ec53-6027-4527-9786-abf8db76c61f",
-          direction: "InOut",
-          endpoint: "@@8FAEBB621D91CB42EA59389EB5C47A9BADEF",
-          properties: {
-            known_since: 16852,
-            distance: 2,
-            is_direct: false,
-            channel_factor: 1,
-            direction: "InOut"
-          }
+            "uuid": "com_interface::a8fc3085-9717-4715-bbed-b20f6128e6df",
+            "properties": {
+                "interface_type": "local",
+                "channel": "local",
+                "direction": "InOut",
+                "round_trip_time": 0,
+                "max_bandwidth": 4294967295,
+                "continuous_connection": false,
+                "allow_redirects": true,
+                "is_secure_channel": false,
+                "reconnection_config": "NoReconnect",
+                "auto_identify": false
+            },
+            "sockets": [
+                {
+                    "uuid": "socket::cb2f1a7e-5fc6-4bd1-acdc-ce796606c6bd",
+                    "direction": "InOut",
+                    "endpoint": "@@local",
+                    "properties": {
+                        "known_since": 0,
+                        "distance": 0,
+                        "is_direct": true,
+                        "channel_factor": 1,
+                        "direction": "InOut"
+                    }
+                }
+            ],
+            "is_waiting_for_socket_connections": false
         }
-      ],
-      is_waiting_for_socket_connections: false
-    }
-  ],
-  endpoint_sockets: {}
+    ],
+    "endpoint_sockets": {}
 })
-
-const expanded = reactive<Record<string, boolean>>({})
-
-type ComHubSocket = {
-  uuid: string
-  direction: string
-  endpoint: string
-  properties: {
-    known_since: number
-    distance: number
-    is_direct: boolean
-    channel_factor: number
-    direction: string
+  
+  const expanded = reactive<Record<string, boolean>>({})
+  
+  function toggle(uuid: string) {
+    expanded[uuid] = !expanded[uuid]
   }
-}
-
-function toggle(uuid: string) {
-  expanded[uuid] = !expanded[uuid]
-}
-
-/**
- * 4. Sorting logic:
- * - Direct sockets first
- * - Then newest first (lower known_since = newer)
- */
-function getSortedSockets(sockets: ComHubSocket[]) {
-  return [...sockets].sort((a, b) => {
-    if (a.properties.is_direct !== b.properties.is_direct) {
-      return a.properties.is_direct ? -1 : 1
-    }
-    return a.properties.known_since - b.properties.known_since
-  })
-}
-
-/**
- * 3. Direction arrows
- */
-function getDirectionArrow(direction: string): string {
-  if (direction === "InOut") return "↔"
-  if (direction === "In") return "←"
-  if (direction === "Out") return "→"
-  return ""
-}
-
-const rtf = new Intl.RelativeTimeFormat(undefined, {
-  numeric: "auto",
-})
-
-function formatTime(seconds: number): string {
-  if (seconds < 60) {
-    return rtf.format(-seconds, "second")
+  
+  function formatTime(seconds: number): string {
+    if (seconds < 60) return `${seconds}s ago`
+    const minutes = Math.floor(seconds / 60)
+    if (minutes < 60) return `${minutes}m ago`
+    const hours = Math.floor(minutes / 60)
+    return `${hours}h ago`
   }
-
-  const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) {
-    return rtf.format(-minutes, "minute")
-  }
-
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) {
-    return rtf.format(-hours, "hour")
-  }
-
-  const days = Math.floor(hours / 24)
-  return rtf.format(-days, "day")
-}
-</script>
+  </script>
+  

--- a/src/components/ComHubOverview.vue
+++ b/src/components/ComHubOverview.vue
@@ -1,9 +1,19 @@
 <template>
   <div class="m-5 p-4 h-full overflow-auto">
-    <h2 class="text-lg font-semibold mb-4">ComHub Overview</h2>
+    <h2 class="text-lg font-semibold mb-3">ComHub Overview</h2>
+
+<!-- Search Bar -->
+<div class="mb-4">
+  <input
+    v-model="searchQuery"
+    type="text"
+    placeholder="Search endpoint identifier (e.g. @@...)"
+    class="w-full px-3 py-2 text-sm rounded border bg-white dark:bg-neutral-900 dark:border-neutral-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+  />
+</div>
 
     <div
-      v-for="iface in comhub.interfaces"
+      v-for="iface in filteredInterfaces"
       :key="iface.uuid"
       class="border rounded-lg p-3 mb-3 bg-white dark:bg-neutral-900 shadow-sm"
     >
@@ -68,67 +78,101 @@
       </div>
     </div>
   </div>
-    <div v-if="!comhub.interfaces.length" class="text-sm text-neutral-500">
-      No active interfaces found.
-    </div>
+  <div
+  v-if="filteredInterfaces.length === 0"
+  class="text-sm text-neutral-500"
+>
+  No matching endpoints found.
+</div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { reactive } from 'vue'
+import { reactive, ref, computed } from 'vue'
 
+const searchQuery = ref('')
 /**
  * TEMP MOCK DATA (from issue JSON)
  * TODO: Replace mock JSON with live ComHub runtime state
  */
 const comhub = reactive({
-  endpoint: "@@FB2D5CF3FBE8CF00FC4518DAF76A189602E1",
-  interfaces: [
-    {
-      uuid: "com_interface::28a6b060-055c-4d20-a715-9bafd9edb90d",
-      properties: {
-        interface_type: "websocket-client",
-        channel: "websocket",
-        name: "ws://localhost:8043",
-        direction: "InOut",
-        round_trip_time: 40,
-        max_bandwidth: 1000,
-        continuous_connection: false,
-        allow_redirects: true,
-        is_secure_channel: false,
-        reconnection_config: "NoReconnect",
-        auto_identify: true
-      },
-      sockets: [
+    "endpoint": "@@FB2D5CF3FBE8CF00FC4518DAF76A189602E1",
+    "interfaces": [
         {
-          uuid: "socket::4a17ec53-6027-4527-9786-abf8db76c61f",
-          direction: "InOut",
-          endpoint: "@server",
-          properties: {
-            known_since: 4,
-            distance: 1,
-            is_direct: true,
-            channel_factor: 1,
-            direction: "InOut"
-          }
+            "uuid": "com_interface::28a6b060-055c-4d20-a715-9bafd9edb90d",
+            "properties": {
+                "interface_type": "websocket-client",
+                "channel": "websocket",
+                "name": "ws://localhost:8043",
+                "direction": "InOut",
+                "round_trip_time": 40,
+                "max_bandwidth": 1000,
+                "continuous_connection": false,
+                "allow_redirects": true,
+                "is_secure_channel": false,
+                "reconnection_config": "NoReconnect",
+                "auto_identify": true
+            },
+            "sockets": [
+                {
+                    "uuid": "socket::4a17ec53-6027-4527-9786-abf8db76c61f",
+                    "direction": "InOut",
+                    "endpoint": "@server",
+                    "properties": {
+                        "known_since": 4,
+                        "distance": 1,
+                        "is_direct": true,
+                        "channel_factor": 1,
+                        "direction": "InOut"
+                    }
+                },
+                {
+                    "uuid": "socket::4a17ec53-6027-4527-9786-abf8db76c61f",
+                    "direction": "InOut",
+                    "endpoint": "@@8FAEBB621D91CB42EA59389EB5C47A9BADEF",
+                    "properties": {
+                        "known_since": 16852,
+                        "distance": 2,
+                        "is_direct": false,
+                        "channel_factor": 1,
+                        "direction": "InOut"
+                    }
+                }
+            ],
+            "is_waiting_for_socket_connections": false
         },
         {
-          uuid: "socket::4a17ec53-6027-4527-9786-abf8db76c61f",
-          direction: "InOut",
-          endpoint: "@@8FAEBB621D91CB42EA59389EB5C47A9BADEF",
-          properties: {
-            known_since: 16852,
-            distance: 2,
-            is_direct: false,
-            channel_factor: 1,
-            direction: "InOut"
-          }
+            "uuid": "com_interface::a8fc3085-9717-4715-bbed-b20f6128e6df",
+            "properties": {
+                "interface_type": "local",
+                "channel": "local",
+                "direction": "InOut",
+                "round_trip_time": 0,
+                "max_bandwidth": 4294967295,
+                "continuous_connection": false,
+                "allow_redirects": true,
+                "is_secure_channel": false,
+                "reconnection_config": "NoReconnect",
+                "auto_identify": false
+            },
+            "sockets": [
+                {
+                    "uuid": "socket::cb2f1a7e-5fc6-4bd1-acdc-ce796606c6bd",
+                    "direction": "InOut",
+                    "endpoint": "@@local",
+                    "properties": {
+                        "known_since": 0,
+                        "distance": 0,
+                        "is_direct": true,
+                        "channel_factor": 1,
+                        "direction": "InOut"
+                    }
+                }
+            ],
+            "is_waiting_for_socket_connections": false
         }
-      ],
-      is_waiting_for_socket_connections: false
-    }
-  ],
-  endpoint_sockets: {}
+    ],
+    "endpoint_sockets": {}
 })
 
 const expanded = reactive<Record<string, boolean>>({})
@@ -145,6 +189,30 @@ type ComHubSocket = {
     direction: string
   }
 }
+
+const filteredInterfaces = computed(() => {
+  const query = searchQuery.value.trim().toLowerCase()
+
+  // If no search, return all interfaces unchanged
+  if (!query) return comhub.interfaces
+
+  return comhub.interfaces
+    .map((iface) => {
+      const matchingSockets = iface.sockets.filter((socket) =>
+        socket.endpoint.toLowerCase().includes(query)
+      )
+
+      // If no matching sockets, this interface should be hidden
+      if (matchingSockets.length === 0) return null
+
+      // Return a shallow copy with ONLY matching sockets
+      return {
+        ...iface,
+        sockets: matchingSockets,
+      }
+    })
+    .filter((iface): iface is typeof comhub.interfaces[number] => iface !== null)
+})
 
 function toggle(uuid: string) {
   expanded[uuid] = !expanded[uuid]

--- a/src/components/ComHubOverview.vue
+++ b/src/components/ComHubOverview.vue
@@ -160,11 +160,26 @@ function getDirectionArrow(direction: string): string {
   return ""
 }
 
+const rtf = new Intl.RelativeTimeFormat(undefined, {
+  numeric: "auto",
+})
+
 function formatTime(seconds: number): string {
-  if (seconds < 60) return `${seconds}s ago`
+  if (seconds < 60) {
+    return rtf.format(-seconds, "second")
+  }
+
   const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes}m ago`
+  if (minutes < 60) {
+    return rtf.format(-minutes, "minute")
+  }
+
   const hours = Math.floor(minutes / 60)
-  return `${hours}h ago`
+  if (hours < 24) {
+    return rtf.format(-hours, "hour")
+  }
+
+  const days = Math.floor(hours / 24)
+  return rtf.format(-days, "day")
 }
 </script>

--- a/src/components/ComHubOverview.vue
+++ b/src/components/ComHubOverview.vue
@@ -34,11 +34,12 @@
       </div>
 
       <!-- Expanded Socket List -->
-      <div v-if="expanded[iface.uuid]" class="mt-3 border-t pt-3">
+      <div v-if="expanded[iface.uuid]" class="mt-3 border-t py-2">
+        <div class="flex flex-col gap-2">
         <div
           v-for="socket in getSortedSockets(iface.sockets)"
           :key="socket.uuid + socket.endpoint"
-          class="text-sm p-3 rounded bg-neutral-100 dark:bg-neutral-800 mb-2"
+          class="text-sm p-3 rounded bg-neutral-100 dark:bg-neutral-800"
         >
           <!-- 5. Endpoint highlighted as heading + 7. direct label + 3. arrow -->
           <h4 class="font-semibold flex items-center gap-2">
@@ -59,14 +60,15 @@
           </h4>
 
           <!-- 6. Distance + time in one line with bullet -->
-          <div class="text-xs text-neutral-500 mt-1">
-            Distance: {{ socket.properties.distance }}
-            • {{ formatTime(socket.properties.known_since) }}
+          <div class="text-xs text-neutral-500 mt-1 space-y-0.5">
+             <div>Distance: {{ socket.properties.distance }}</div>
+            <div>Created: {{ formatTime(socket.properties.known_since) }}
+          </div>
           </div>
         </div>
       </div>
     </div>
-
+  </div>
     <div v-if="!comhub.interfaces.length" class="text-sm text-neutral-500">
       No active interfaces found.
     </div>

--- a/src/components/ComHubOverview.vue
+++ b/src/components/ComHubOverview.vue
@@ -1,163 +1,170 @@
 <template>
-    <div class="m-5 p-4 h-full overflow-auto">
-      <h2 class="text-lg font-semibold mb-4">ComHub Overview</h2>
-  
+  <div class="m-5 p-4 h-full overflow-auto">
+    <h2 class="text-lg font-semibold mb-4">ComHub Overview</h2>
+
+    <div
+      v-for="iface in comhub.interfaces"
+      :key="iface.uuid"
+      class="border rounded-lg p-3 mb-3 bg-white dark:bg-neutral-900 shadow-sm"
+    >
+      <!-- Interface Header -->
       <div
-        v-for="iface in comhub.interfaces"
-        :key="iface.uuid"
-        class="border rounded-lg p-3 mb-3 bg-white dark:bg-neutral-900 shadow-sm"
+        class="flex justify-between items-center cursor-pointer"
+        @click="toggle(iface.uuid)"
       >
-        <!-- Interface Header -->
-        <div
-          class="flex justify-between items-center cursor-pointer"
-          @click="toggle(iface.uuid)"
-        >
-          <div>
-            <div class="font-medium">
-              {{ iface.properties.name || iface.properties.interface_type }}
-            </div>
-  
-            <div class="text-xs text-neutral-500 mt-1">
-              Type: {{ iface.properties.interface_type }}
-              • Sockets: {{ iface.sockets.length }}
-            </div>
-          </div>
-  
-          <div class="text-xs text-neutral-400">
-            RTT: {{ iface.properties.round_trip_time }} ms
+        <div>
+          <!-- 1. Channel type prominent + name -->
+          <h3 class="font-semibold">
+            {{ iface.properties.interface_type }}
+            <span v-if="iface.properties.name">
+              ({{ iface.properties.name }})
+            </span>
+          </h3>
+
+          <!-- 2. Show channel next to socket count -->
+          <div class="text-xs text-neutral-500 mt-1">
+            Sockets: {{ iface.sockets.length }}
+            • Channel: {{ iface.properties.channel }}
           </div>
         </div>
-  
-        <!-- Expanded Socket List -->
-        <div v-if="expanded[iface.uuid]" class="mt-3 border-t pt-3">
-          <div
-            v-for="socket in iface.sockets"
-            :key="socket.uuid + socket.endpoint"
-            class="text-sm p-2 rounded bg-neutral-100 dark:bg-neutral-800 mb-2"
-          >
-            <div><strong>Endpoint:</strong> {{ socket.endpoint }}</div>
-            <div>
-              <strong>Direct:</strong>
-              {{ socket.properties.is_direct ? "Direct" : "Indirect" }}
-            </div>
-            <div>
-              <strong>Distance:</strong> {{ socket.properties.distance }}
-            </div>
-            <div>
-              <strong>Time since creation:</strong>
-              {{ formatTime(socket.properties.known_since) }}
-            </div>
-          </div>
+
+        <div class="text-xs text-neutral-400">
+          RTT: {{ iface.properties.round_trip_time }} ms
         </div>
       </div>
-  
-      <div v-if="!comhub.interfaces.length" class="text-sm text-neutral-500">
-        No active interfaces found.
+
+      <!-- Expanded Socket List -->
+      <div v-if="expanded[iface.uuid]" class="mt-3 border-t pt-3">
+        <div
+          v-for="socket in getSortedSockets(iface.sockets)"
+          :key="socket.uuid + socket.endpoint"
+          class="text-sm p-3 rounded bg-neutral-100 dark:bg-neutral-800 mb-2"
+        >
+          <!-- 5. Endpoint highlighted as heading + 7. direct label + 3. arrow -->
+          <h4 class="font-semibold flex items-center gap-2">
+            {{ socket.endpoint }}
+
+            <!-- Direct label only if direct -->
+            <span
+              v-if="socket.properties.is_direct"
+              class="text-xs px-2 py-0.5 rounded bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300"
+            >
+              direct
+            </span>
+
+            <!-- Direction arrow -->
+            <span class="text-neutral-400">
+              {{ getDirectionArrow(socket.direction) }}
+            </span>
+          </h4>
+
+          <!-- 6. Distance + time in one line with bullet -->
+          <div class="text-xs text-neutral-500 mt-1">
+            Distance: {{ socket.properties.distance }}
+            • {{ formatTime(socket.properties.known_since) }}
+          </div>
+        </div>
       </div>
     </div>
-  </template>
-  
-  <script setup lang="ts">
-  import { reactive } from 'vue'
-  
-  /**
-   * TEMP MOCK DATA (from issue JSON)
-   * Replace later with real ComHub runtime state
-   * TODO: Replace mock JSON with live ComHub runtime state
-   */
 
-    const comhub = reactive({
-    "endpoint": "@@FB2D5CF3FBE8CF00FC4518DAF76A189602E1",
-    "interfaces": [
+    <div v-if="!comhub.interfaces.length" class="text-sm text-neutral-500">
+      No active interfaces found.
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive } from 'vue'
+
+/**
+ * TEMP MOCK DATA (from issue JSON)
+ * TODO: Replace mock JSON with live ComHub runtime state
+ */
+const comhub = reactive({
+  endpoint: "@@FB2D5CF3FBE8CF00FC4518DAF76A189602E1",
+  interfaces: [
+    {
+      uuid: "com_interface::28a6b060-055c-4d20-a715-9bafd9edb90d",
+      properties: {
+        interface_type: "websocket-client",
+        channel: "websocket",
+        name: "ws://localhost:8043",
+        direction: "InOut",
+        round_trip_time: 40,
+        max_bandwidth: 1000,
+        continuous_connection: false,
+        allow_redirects: true,
+        is_secure_channel: false,
+        reconnection_config: "NoReconnect",
+        auto_identify: true
+      },
+      sockets: [
         {
-            "uuid": "com_interface::28a6b060-055c-4d20-a715-9bafd9edb90d",
-            "properties": {
-                "interface_type": "websocket-client",
-                "channel": "websocket",
-                "name": "ws://localhost:8043",
-                "direction": "InOut",
-                "round_trip_time": 40,
-                "max_bandwidth": 1000,
-                "continuous_connection": false,
-                "allow_redirects": true,
-                "is_secure_channel": false,
-                "reconnection_config": "NoReconnect",
-                "auto_identify": true
-            },
-            "sockets": [
-                {
-                    "uuid": "socket::4a17ec53-6027-4527-9786-abf8db76c61f",
-                    "direction": "InOut",
-                    "endpoint": "@server",
-                    "properties": {
-                        "known_since": 4,
-                        "distance": 1,
-                        "is_direct": true,
-                        "channel_factor": 1,
-                        "direction": "InOut"
-                    }
-                },
-                {
-                    "uuid": "socket::4a17ec53-6027-4527-9786-abf8db76c61f",
-                    "direction": "InOut",
-                    "endpoint": "@@8FAEBB621D91CB42EA59389EB5C47A9BADEF",
-                    "properties": {
-                        "known_since": 16852,
-                        "distance": 2,
-                        "is_direct": false,
-                        "channel_factor": 1,
-                        "direction": "InOut"
-                    }
-                }
-            ],
-            "is_waiting_for_socket_connections": false
+          uuid: "socket::4a17ec53-6027-4527-9786-abf8db76c61f",
+          direction: "InOut",
+          endpoint: "@server",
+          properties: {
+            known_since: 4,
+            distance: 1,
+            is_direct: true,
+            channel_factor: 1,
+            direction: "InOut"
+          }
         },
         {
-            "uuid": "com_interface::a8fc3085-9717-4715-bbed-b20f6128e6df",
-            "properties": {
-                "interface_type": "local",
-                "channel": "local",
-                "direction": "InOut",
-                "round_trip_time": 0,
-                "max_bandwidth": 4294967295,
-                "continuous_connection": false,
-                "allow_redirects": true,
-                "is_secure_channel": false,
-                "reconnection_config": "NoReconnect",
-                "auto_identify": false
-            },
-            "sockets": [
-                {
-                    "uuid": "socket::cb2f1a7e-5fc6-4bd1-acdc-ce796606c6bd",
-                    "direction": "InOut",
-                    "endpoint": "@@local",
-                    "properties": {
-                        "known_since": 0,
-                        "distance": 0,
-                        "is_direct": true,
-                        "channel_factor": 1,
-                        "direction": "InOut"
-                    }
-                }
-            ],
-            "is_waiting_for_socket_connections": false
+          uuid: "socket::4a17ec53-6027-4527-9786-abf8db76c61f",
+          direction: "InOut",
+          endpoint: "@@8FAEBB621D91CB42EA59389EB5C47A9BADEF",
+          properties: {
+            known_since: 16852,
+            distance: 2,
+            is_direct: false,
+            channel_factor: 1,
+            direction: "InOut"
+          }
         }
-    ],
-    "endpoint_sockets": {}
+      ],
+      is_waiting_for_socket_connections: false
+    }
+  ],
+  endpoint_sockets: {}
 })
-  
-  const expanded = reactive<Record<string, boolean>>({})
-  
-  function toggle(uuid: string) {
-    expanded[uuid] = !expanded[uuid]
-  }
-  
-  function formatTime(seconds: number): string {
-    if (seconds < 60) return `${seconds}s ago`
-    const minutes = Math.floor(seconds / 60)
-    if (minutes < 60) return `${minutes}m ago`
-    const hours = Math.floor(minutes / 60)
-    return `${hours}h ago`
-  }
-  </script>
-  
+
+const expanded = reactive<Record<string, boolean>>({})
+
+function toggle(uuid: string) {
+  expanded[uuid] = !expanded[uuid]
+}
+
+/**
+ * 4. Sorting logic:
+ * - Direct sockets first
+ * - Then newest first (lower known_since = newer)
+ */
+function getSortedSockets(sockets: any[]) {
+  return [...sockets].sort((a, b) => {
+    if (a.properties.is_direct !== b.properties.is_direct) {
+      return a.properties.is_direct ? -1 : 1
+    }
+    return a.properties.known_since - b.properties.known_since
+  })
+}
+
+/**
+ * 3. Direction arrows
+ */
+function getDirectionArrow(direction: string): string {
+  if (direction === "InOut") return "↔"
+  if (direction === "In") return "←"
+  if (direction === "Out") return "→"
+  return ""
+}
+
+function formatTime(seconds: number): string {
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  return `${hours}h ago`
+}
+</script>

--- a/src/components/ComHubOverview.vue
+++ b/src/components/ComHubOverview.vue
@@ -132,6 +132,19 @@ const comhub = reactive({
 
 const expanded = reactive<Record<string, boolean>>({})
 
+type ComHubSocket = {
+  uuid: string
+  direction: string
+  endpoint: string
+  properties: {
+    known_since: number
+    distance: number
+    is_direct: boolean
+    channel_factor: number
+    direction: string
+  }
+}
+
 function toggle(uuid: string) {
   expanded[uuid] = !expanded[uuid]
 }
@@ -141,7 +154,7 @@ function toggle(uuid: string) {
  * - Direct sockets first
  * - Then newest first (lower known_since = newer)
  */
-function getSortedSockets(sockets: any[]) {
+function getSortedSockets(sockets: ComHubSocket[]) {
   return [...sockets].sort((a, b) => {
     if (a.properties.is_direct !== b.properties.is_direct) {
       return a.properties.is_direct ? -1 : 1

--- a/src/components/ComHubOverview.vue
+++ b/src/components/ComHubOverview.vue
@@ -12,6 +12,14 @@
   />
 </div>
 
+<!-- Advanced Mode Toggle -->
+<div class="mb-4 flex items-center gap-2">
+  <label class="text-sm text-neutral-500 cursor-pointer select-none flex items-center gap-2">
+    <input type="checkbox" v-model="advancedMode" class="accent-blue-500" />
+    Advanced Mode
+  </label>
+</div>
+
     <div
       v-for="iface in filteredInterfaces"
       :key="iface.uuid"
@@ -69,6 +77,15 @@
             </span>
           </h4>
 
+  <!-- Disconnect button (Advanced Mode only) -->
+  <button
+     v-if="advancedMode"
+     @click.stop="disconnectSocket(iface.uuid, socket.uuid, socket.endpoint)"
+     class="mt-2 text-xs px-2 py-1 rounded bg-red-100 text-red-600 hover:bg-red-200 dark:bg-red-900 dark:text-red-300 dark:hover:bg-red-800"
+      >
+    Disconnect
+    </button>
+
           <!-- 6. Distance + time in one line with bullet -->
           <div class="text-xs text-neutral-500 mt-1">
              Distance: {{ socket.properties.distance }}
@@ -88,9 +105,12 @@
 </template>
 
 <script setup lang="ts">
-import { reactive, ref, computed } from 'vue'
+import { reactive, ref, computed, watch } from 'vue'
 
 const searchQuery = ref('')
+
+const advancedMode = ref(false) // 
+
 /**
  * TEMP MOCK DATA (from issue JSON)
  * TODO: Replace mock JSON with live ComHub runtime state
@@ -204,6 +224,7 @@ const filteredInterfaces = computed(() => {
 
       // If no matching sockets, this interface should be hidden
       if (matchingSockets.length === 0) return null
+      expanded[iface.uuid] = true
 
       // Return a shallow copy with ONLY matching sockets
       return {
@@ -212,6 +233,14 @@ const filteredInterfaces = computed(() => {
       }
     })
     .filter((iface): iface is typeof comhub.interfaces[number] => iface !== null)
+})
+
+watch(searchQuery, (val) => {
+  if (!val.trim()) {
+    Object.keys(expanded).forEach((key) => {
+      expanded[key] = false
+    })
+  }
 })
 
 function toggle(uuid: string) {
@@ -264,4 +293,13 @@ function formatTime(seconds: number): string {
   const days = Math.floor(hours / 24)
   return rtf.format(-days, "day")
 }
+
+/**
+ * TODO: Implement once new DATEX release is available
+ * Disconnects a socket from its interface
+ */
+ function disconnectSocket(interfaceUuid: string, socketUuid: string, endpoint: string) {
+  console.warn(`[ComHub] disconnectSocket stub called`, { interfaceUuid, socketUuid, endpoint })
+}
+
 </script>

--- a/src/components/Window.vue
+++ b/src/components/Window.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import ComHubOverview from '@/components/ComHubOverview.vue';
-import ComHubOverview from '@/components/ComHubOverview.vue';
 import { useDragDrop } from '@/composable/useDragDrop.ts';
 import { collapseSplit } from '@/composable/useLayoutTree.ts';
 import {
@@ -160,12 +158,6 @@ function collapseNearSide(node: SplitNode, side: CollapseSide): void {
         {{ dropPreview.mode === DropMode.Insert ? 'Insert' : 'Replace' }}
       </div>
     </div>
-
-    <!-- PANEL CONTENT -->
-    <div class="w-full h-full">
-  <ComHubOverview />
-</div>
-
 
   </div>
 

--- a/src/components/Window.vue
+++ b/src/components/Window.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
 import ComHubOverview from '@/components/ComHubOverview.vue';
+import ComHubOverview from '@/components/ComHubOverview.vue';
 import { useDragDrop } from '@/composable/useDragDrop.ts';
 import { collapseSplit } from '@/composable/useLayoutTree.ts';
 import {
-    CollapseSide,
-    type LayoutNode,
-    NodeType,
-    SplitDirection,
-    type SplitNode,
+  CollapseSide,
+  type LayoutNode,
+  NodeType,
+  SplitDirection,
+  type SplitNode,
 } from '@/types/layout.ts';
 import { reactive } from 'vue';
 import Window from './Window.vue';
@@ -21,32 +22,32 @@ const gutterDragState = reactive<{ activeNodeId: string | null }>({ activeNodeId
  * Destructure reusable drag & drop logic for this node
  */
 const { dragState, dropPreview, onDragEnter, onDragLeave, onDragOver, onDrop, DropMode } =
-    useDragDrop(props.node);
+  useDragDrop(props.node);
 
 /**
  * Starts dragging the gutter of a split node
  */
 function startGutterDrag(): void {
-    dragState.active = true;
-    gutterDragState.activeNodeId = props.node.id;
-    dragState.nearCollapse = CollapseSide.None;
+  dragState.active = true;
+  gutterDragState.activeNodeId = props.node.id;
+  dragState.nearCollapse = CollapseSide.None;
 }
 
 /**
  * Stops dragging the gutter and collapses a side if near a boundary
  */
 function stopGutterDrag(): void {
-    if (gutterDragState.activeNodeId !== props.node.id) return;
-    if (props.node.type !== NodeType.Split) return; // only split nodes can be dragged
+  if (gutterDragState.activeNodeId !== props.node.id) return;
+  if (props.node.type !== NodeType.Split) return; // only split nodes can be dragged
 
-    gutterDragState.activeNodeId = null;
-    dragState.active = false;
+  gutterDragState.activeNodeId = null;
+  dragState.active = false;
 
-    if (dragState.nearCollapse) {
-        collapseNearSide(props.node, dragState.nearCollapse);
-    }
+  if (dragState.nearCollapse) {
+    collapseNearSide(props.node, dragState.nearCollapse);
+  }
 
-    dragState.nearCollapse = CollapseSide.None;
+  dragState.nearCollapse = CollapseSide.None;
 }
 
 /**
@@ -55,12 +56,12 @@ function stopGutterDrag(): void {
  * @param e MouseEvent triggered on gutter movement
  */
 function onGutterDrag(e: MouseEvent): void {
-    if (gutterDragState.activeNodeId !== props.node.id) return;
+  if (gutterDragState.activeNodeId !== props.node.id) return;
 
-    const node = props.node as SplitNode;
-    const ratio = calculateSplitRatio(e, node);
-    node.splitRatio = ratio;
-    dragState.nearCollapse = determineNearCollapse(ratio, node);
+  const node = props.node as SplitNode;
+  const ratio = calculateSplitRatio(e, node);
+  node.splitRatio = ratio;
+  dragState.nearCollapse = determineNearCollapse(ratio, node);
 }
 
 /**
@@ -70,14 +71,14 @@ function onGutterDrag(e: MouseEvent): void {
  * @returns number split ratio between 0.05 and 0.95
  */
 function calculateSplitRatio(e: MouseEvent, node: SplitNode): number {
-    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-    const ratio =
-        node.direction === SplitDirection.Vertical
-            ? (e.clientX - rect.left) / rect.width
-            : (e.clientY - rect.top) / rect.height;
+  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+  const ratio =
+    node.direction === SplitDirection.Vertical
+      ? (e.clientX - rect.left) / rect.width
+      : (e.clientY - rect.top) / rect.height;
 
-    // Clamp ratio to prevent collapse beyond the threshold
-    return Math.min(0.95, Math.max(0.05, ratio));
+  // Clamp ratio to prevent collapse beyond the threshold
+  return Math.min(0.95, Math.max(0.05, ratio));
 }
 
 /**
@@ -87,13 +88,11 @@ function calculateSplitRatio(e: MouseEvent, node: SplitNode): number {
  * @returns CollapseSide if near a boundary, otherwise CollapseSide.None
  */
 function determineNearCollapse(ratio: number, node: SplitNode): CollapseSide {
-    if (ratio <= 0.15)
-        return node.direction === SplitDirection.Vertical ? CollapseSide.Left : CollapseSide.Top;
-    if (ratio >= 0.85)
-        return node.direction === SplitDirection.Vertical
-            ? CollapseSide.Right
-            : CollapseSide.Bottom;
-    return CollapseSide.None;
+  if (ratio <= 0.15)
+    return node.direction === SplitDirection.Vertical ? CollapseSide.Left : CollapseSide.Top;
+  if (ratio >= 0.85)
+    return node.direction === SplitDirection.Vertical ? CollapseSide.Right : CollapseSide.Bottom;
+  return CollapseSide.None;
 }
 
 /**
@@ -102,69 +101,65 @@ function determineNearCollapse(ratio: number, node: SplitNode): CollapseSide {
  * @param side Side to collapse (left/top or right/bottom)
  */
 function collapseNearSide(node: SplitNode, side: CollapseSide): void {
-    const keepIndex = side === CollapseSide.Left || side === CollapseSide.Top ? 1 : 0;
-    const nodeToKeep = node.children[keepIndex];
-    if (!nodeToKeep) return;
-    collapseSplit(nodeToKeep);
+  const keepIndex = side === CollapseSide.Left || side === CollapseSide.Top ? 1 : 0;
+  const nodeToKeep = node.children[keepIndex];
+  if (!nodeToKeep) return;
+  collapseSplit(nodeToKeep);
 }
 </script>
 
 <template>
-    <!-- PANEL -->
+  <!-- PANEL -->
+  <div
+    v-if="node.type === NodeType.Panel"
+    class="w-full h-full relative bg-neutral-50 dark:bg-neutral-950 overflow-hidden transition-opacity"
+    @dragenter="onDragEnter"
+    @dragover="onDragOver"
+    @dragleave="onDragLeave"
+    @drop="onDrop"
+  >
     <div
-        v-if="node.type === NodeType.Panel"
-        class="w-full h-full relative bg-neutral-50 dark:bg-neutral-950 overflow-hidden transition-opacity"
-        @dragenter="onDragEnter"
-        @dragover="onDragOver"
-        @dragleave="onDragLeave"
-        @drop="onDrop"
+      class="absolute top-0 left-0 right-0 h-6 flex items-center justify-between bg-neutral-200/70 dark:bg-neutral-800/70 backdrop-blur-sm border-b border-neutral-300/50 text-xs text-neutral-700 dark:text-neutral-300 px-2 select-none cursor-grab active:cursor-grabbing"
+      draggable="true"
+      @dragstart="
+        (e) => {
+          e.dataTransfer?.setData('text/plain', node.id);
+        }
+      "
     >
-        <div
-            class="absolute top-0 left-0 right-0 h-6 flex items-center justify-between bg-neutral-200/70 dark:bg-neutral-800/70 backdrop-blur-sm border-b border-neutral-300/50 text-xs text-neutral-700 dark:text-neutral-300 px-2 select-none cursor-grab active:cursor-grabbing"
-            draggable="true"
-            @dragstart="
-                (e) => {
-                    e.dataTransfer?.setData('text/plain', node.id);
-                }
-            "
-        >
-            <div class="flex items-center gap-1">
-                <svg
-                    class="w-3 h-3 opacity-70"
-                    viewBox="0 0 20 20"
-                    xmlns="http://www.w3.org/2000/svg"
-                >
-                    <circle cx="5" cy="10" r="2" />
-                    <circle cx="10" cy="10" r="2" />
-                    <circle cx="15" cy="10" r="2" />
-                </svg>
-                <span>{{ node.id }}</span>
-            </div>
-        </div>
+      <div class="flex items-center gap-1">
+        <svg class="w-3 h-3 opacity-70" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="5" cy="10" r="2" />
+          <circle cx="10" cy="10" r="2" />
+          <circle cx="15" cy="10" r="2" />
+        </svg>
+        <span>{{ node.id }}</span>
+      </div>
+    </div>
 
-        <!-- Drop preview overlay -->
-        <div
-            v-if="dropPreview.active"
-            class="absolute inset-0 backdrop-blur-sm bg-white/30 dark:bg-black/20 flex items-center justify-center transition-all"
-        >
-            <!-- Area highlight -->
-            <div
-                class="absolute inset-0 rounded-lg transition-all duration-150 border-2 border-primary/40 bg-primary/20"
-                :class="{
-                    'clip-top': dropPreview.area === 'top',
-                    'clip-bottom': dropPreview.area === 'bottom',
-                    'clip-left': dropPreview.area === 'left',
-                    'clip-right': dropPreview.area === 'right',
-                    'clip-center': dropPreview.area === 'center',
-                }"
-            ></div>
+    <!-- Drop preview overlay -->
+    <div
+      v-if="dropPreview.active"
+      class="absolute inset-0 backdrop-blur-sm bg-white/30 dark:bg-black/20 flex items-center justify-center transition-all"
+    >
+      <!-- Area highlight -->
+      <div
+        class="absolute inset-0 rounded-lg transition-all duration-150 border-2 border-primary/40 bg-primary/20"
+        :class="{
+          'clip-top': dropPreview.area === 'top',
+          'clip-bottom': dropPreview.area === 'bottom',
+          'clip-left': dropPreview.area === 'left',
+          'clip-right': dropPreview.area === 'right',
+          'clip-center': dropPreview.area === 'center',
+        }"
+      ></div>
 
-            <div
-                class="px-3 py-1 rounded-md bg-primary text-primary-foreground text-xs shadow-lg backdrop-blur-md"
-            >
-                {{ dropPreview.mode === DropMode.Insert ? 'Insert' : 'Replace' }}
-            </div>
-        </div>
+      <div
+        class="px-3 py-1 rounded-md bg-primary text-primary-foreground text-xs shadow-lg backdrop-blur-md"
+      >
+        {{ dropPreview.mode === DropMode.Insert ? 'Insert' : 'Replace' }}
+      </div>
+    </div>
 
     <!-- PANEL CONTENT -->
     <div class="w-full h-full">
@@ -174,71 +169,70 @@ function collapseNearSide(node: SplitNode, side: CollapseSide): void {
 
   </div>
 
-    <!-- SPLIT -->
+  <!-- SPLIT -->
+  <div
+    v-else
+    class="w-full h-full select-none flex transition-all"
+    :class="node.direction === SplitDirection.Vertical ? 'flex-row' : 'flex-col'"
+    @mousemove="onGutterDrag"
+    @mouseup="stopGutterDrag"
+  >
+    <!-- first child -->
     <div
-        v-else
-        class="w-full h-full select-none flex transition-all"
-        :class="node.direction === SplitDirection.Vertical ? 'flex-row' : 'flex-col'"
-        @mousemove="onGutterDrag"
-        @mouseup="stopGutterDrag"
+      class="flex-none transition-opacity duration-150"
+      :class="{
+        'opacity-30': dragState.nearCollapse === 'left' || dragState.nearCollapse === 'top',
+      }"
+      :style="{ flexBasis: `${node.splitRatio * 100}%` }"
     >
-        <!-- first child -->
-        <div
-            class="flex-none transition-opacity duration-150"
-            :class="{
-                'opacity-30': dragState.nearCollapse === 'left' || dragState.nearCollapse === 'top',
-            }"
-            :style="{ flexBasis: `${node.splitRatio * 100}%` }"
-        >
-            <Window :node="node.children[0]" />
-        </div>
-
-        <!-- gutter -->
-        <div
-            :class="[
-                node.direction === SplitDirection.Vertical
-                    ? 'cursor-col-resize w-1 m-1 bg-neutral-100 dark:bg-neutral-950 hover:bg-neutral-300 dark:hover:bg-neutral-700 rounded'
-                    : 'cursor-row-resize h-1 m-1 bg-neutral-100 dark:bg-neutral-950 hover:bg-neutral-300 dark:hover:bg-neutral-700 rounded',
-            ]"
-            @mousedown="startGutterDrag"
-        ></div>
-
-        <!-- second child -->
-        <div
-            class="flex-auto transition-opacity duration-150"
-            :class="{
-                'opacity-30':
-                    dragState.nearCollapse === 'right' || dragState.nearCollapse === 'bottom',
-            }"
-        >
-            <Window :node="node.children[1]" />
-        </div>
+      <Window :node="node.children[0]" />
     </div>
+
+    <!-- gutter -->
+    <div
+      :class="[
+        node.direction === SplitDirection.Vertical
+          ? 'cursor-col-resize w-1 m-1 bg-neutral-100 dark:bg-neutral-950 hover:bg-neutral-300 dark:hover:bg-neutral-700 rounded'
+          : 'cursor-row-resize h-1 m-1 bg-neutral-100 dark:bg-neutral-950 hover:bg-neutral-300 dark:hover:bg-neutral-700 rounded',
+      ]"
+      @mousedown="startGutterDrag"
+    ></div>
+
+    <!-- second child -->
+    <div
+      class="flex-auto transition-opacity duration-150"
+      :class="{
+        'opacity-30': dragState.nearCollapse === 'right' || dragState.nearCollapse === 'bottom',
+      }"
+    >
+      <Window :node="node.children[1]" />
+    </div>
+  </div>
 </template>
 
 <style scoped>
 .clip-top {
-    clip-path: inset(0 0 50% 0);
-    transition: clip-path 0.3s ease-in-out;
+  clip-path: inset(0 0 50% 0);
+  transition: clip-path 0.3s ease-in-out;
 }
 
 .clip-bottom {
-    clip-path: inset(50% 0 0 0);
-    transition: clip-path 0.3s ease-in-out;
+  clip-path: inset(50% 0 0 0);
+  transition: clip-path 0.3s ease-in-out;
 }
 
 .clip-left {
-    clip-path: inset(0 50% 0 0);
-    transition: clip-path 0.3s ease-in-out;
+  clip-path: inset(0 50% 0 0);
+  transition: clip-path 0.3s ease-in-out;
 }
 
 .clip-right {
-    clip-path: inset(0 0 0 50%);
-    transition: clip-path 0.3s ease-in-out;
+  clip-path: inset(0 0 0 50%);
+  transition: clip-path 0.3s ease-in-out;
 }
 
 .clip-center {
-    clip-path: inset(10% 10% 10% 10%);
-    transition: clip-path 0.3s ease-in-out;
+  clip-path: inset(10% 10% 10% 10%);
+  transition: clip-path 0.3s ease-in-out;
 }
 </style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -16,10 +16,20 @@ const router = createRouter({
       component: () => import('@/views/BlockViewer/DatexBlockProtocolViewWrapper.vue'),
     },
     {
-      path: '',
+      path: '/',
       name: 'Editor',
       component: WindowGeneralView,
     },
+    {
+      path: '/comhub',
+      name: 'comhub-overview',
+      component: () => import('@/components/ComHubOverview.vue'),
+    },
+    {
+      path: '/u/:endpoint_id',
+      name: 'endpoint-view',
+      component: () => import('@/components/endpoint/EndpointView.vue')
+    }
   ],
 });
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -16,7 +16,7 @@ const router = createRouter({
       component: () => import('@/views/BlockViewer/DatexBlockProtocolViewWrapper.vue'),
     },
     {
-      path: '',
+      path: '/',
       name: 'Editor',
       component: WindowGeneralView,
     },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -16,7 +16,7 @@ const router = createRouter({
       component: () => import('@/views/BlockViewer/DatexBlockProtocolViewWrapper.vue'),
     },
     {
-      path: '/',
+      path: '',
       name: 'Editor',
       component: WindowGeneralView,
     },
@@ -25,11 +25,6 @@ const router = createRouter({
       name: 'comhub-overview',
       component: () => import('@/components/ComHubOverview.vue'),
     },
-    {
-      path: '/u/:endpoint_id',
-      name: 'endpoint-view',
-      component: () => import('@/components/endpoint/EndpointView.vue')
-    }
   ],
 });
 


### PR DESCRIPTION
## Summary
Adds a search bar to the ComHubOverview to filter sockets by endpoint identifier.

## Changes
- Added a reactive search input at the top of the ComHubOverview
- Implemented computed filtering for hierarchical data (interfaces → sockets)
- Interfaces without matching endpoints are hidden entirely
- Matching interfaces only display filtered sockets

## Technical Notes
- Filtering is implemented via a computed property to avoid mutating runtime/mock ComHub state
- Case-insensitive endpoint matching
- Existing UI structure and gap-based spacing remain unchanged
- Compatible with future live runtime integration