### PR TITLE
feat(welcome): add welcome screen with quick actions

### DIFF
--- a/src/components/HeaderProvider.vue
+++ b/src/components/HeaderProvider.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { useRoute } from 'vue-router'
 import ThemeSwitch from '@/components/ThemeSwitch.vue';
 import IconLogo from '@/components/icons/IconLogo.vue';
 import {
@@ -23,14 +24,19 @@ export default {
         // MenubarMenu,
         Menubar,
         IconLogo,
-        ThemeSwitch,
+        ThemeSwitch },
+        setup() {
+    const route = useRoute()
+    return { route }
     },
 };
 </script>
 
 <template>
     <Menubar class="bg-background wco-header flex w-full items-center px-4 py-3">
-        <RouterLink to="/" class="group mr-4 flex items-center space-x-2 transition-all">
+        <RouterLink to="/" class="group mr-4 flex items-center space-x-2 transition-all"
+        v-show="route.path !== '/'"
+        >
             <IconLogo class="h-6 w-6" />
             <div class="flex items-baseline space-x-1">
                 <span class="text-primary text-lg font-bold">DATEX Workbench</span>

--- a/src/views/WelcomeView.vue
+++ b/src/views/WelcomeView.vue
@@ -1,5 +1,129 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+
+const quickActions = [
+  {
+    label: 'Network Inspector',
+    description: 'Monitor and inspect DATEX network blocks in real time',
+    icon: 'network',
+    route: '/network',
+    available: true,
+  },
+  {
+    label: 'Node View',
+    description: 'Visualize and edit the DATEX node graph',
+    icon: 'node',
+    route: '/node-view',
+    available: true,
+  },
+  {
+    label: 'File Editor',
+    description: 'Edit DATEX files directly in the workbench',
+    icon: 'editor',
+    route: '/editor',
+    available: true,
+  },
+  {
+    label: 'REPL',
+    description: 'Interactive DATEX runtime environment',
+    icon: 'repl',
+    route: null,
+    available: false,
+  },
+]
+
+function navigate(route: string | null) {
+  if (route) router.push(route)
+}
+</script>
 
 <template>
-    <main class="flex h-full w-full items-center justify-center">DATEX Workbench</main>
+  <main class="flex h-full w-full flex-col items-center justify-center gap-12 bg-background p-8">
+    <!-- Header -->
+    <div class="flex flex-col items-center gap-2 text-center">
+      <div class="flex items-center gap-3">
+        <img src="@/assets/logos/datex-logo-rounded-light.svg" alt="DATEX" class="h-10 w-10 dark:hidden" />
+        <img src="@/assets/logos/datex-logo-rounded-dark.svg" alt="DATEX" class="h-10 w-10 hidden dark:block" />        <h1 class="text-3xl font-semibold tracking-tight text-foreground">
+          DATEX Workbench
+        </h1>
+      </div>
+      <p class="text-sm text-muted-foreground">
+        Developer tooling for the DATEX runtime
+      </p>
+    </div>
+
+    <!-- Quick actions -->
+    <div class="w-full max-w-2xl">
+      <p class="mb-4 text-xs font-medium uppercase tracking-widest text-muted-foreground">
+        Quick Actions
+      </p>
+      <div class="grid grid-cols-2 gap-3">
+        <button
+          v-for="action in quickActions"
+          :key="action.label"
+          class="group flex flex-col gap-2 rounded-lg border border-border bg-card p-4 text-left transition-all"
+          :class="action.available
+            ? 'hover:border-primary/50 hover:bg-accent cursor-pointer'
+            : 'opacity-50 cursor-not-allowed'"
+          @click="navigate(action.route)"
+        >
+          <!-- Icon -->
+          <div class="flex items-center justify-between">
+            <div class="flex h-8 w-8 items-center justify-center rounded-md bg-primary/10 text-primary">
+              <!-- Network -->
+              <svg v-if="action.icon === 'network'" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <circle cx="12" cy="5" r="3"/><circle cx="19" cy="19" r="3"/><circle cx="5" cy="19" r="3"/>
+                <line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="12" x2="19" y2="16"/><line x1="12" y1="12" x2="5" y2="16"/>
+              </svg>
+              <!-- Node -->
+              <svg v-else-if="action.icon === 'node'" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/>
+                <rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/>
+                <line x1="10" y1="6.5" x2="14" y2="6.5"/><line x1="6.5" y1="10" x2="6.5" y2="14"/>
+              </svg>
+              <!-- Editor -->
+              <svg v-else-if="action.icon === 'editor'" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                <polyline points="14 2 14 8 20 8"/>
+                <line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/>
+              </svg>
+              <!-- REPL -->
+              <svg v-else-if="action.icon === 'repl'" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/>
+              </svg>
+            </div>
+            <span
+              v-if="!action.available"
+              class="text-xs text-muted-foreground border border-border rounded px-1.5 py-0.5"
+            >
+              Soon
+            </span>
+            <svg
+              v-else
+              class="h-4 w-4 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100"
+              viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            >
+              <line x1="5" y1="12" x2="19" y2="12"/>
+              <polyline points="12 5 19 12 12 19"/>
+            </svg>
+          </div>
+
+          <!-- Text -->
+          <div>
+            <p class="text-sm font-medium text-foreground">{{ action.label }}</p>
+            <p class="text-xs text-muted-foreground">{{ action.description }}</p>
+          </div>
+        </button>
+      </div>
+    </div>
+
+    <!-- Footer links -->
+    <div class="flex gap-6 text-xs text-muted-foreground">
+      <a href="https://unyt.org" target="_blank" class="hover:text-foreground transition-colors">unyt.org</a>
+      <a href="https://github.com/unyt-org/datex-workbench" target="_blank" class="hover:text-foreground transition-colors">GitHub</a>
+      <a href="https://docs.unyt.org" target="_blank" class="hover:text-foreground transition-colors">Docs</a>
+    </div>
+  </main>
 </template>

--- a/src/views/WelcomeView.vue
+++ b/src/views/WelcomeView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useRouter } from 'vue-router'
+import IconLogo from '@/components/icons/IconLogo.vue'
 
 const router = useRouter()
 
@@ -44,8 +45,8 @@ function navigate(route: string | null) {
     <!-- Header -->
     <div class="flex flex-col items-center gap-2 text-center">
       <div class="flex items-center gap-3">
-        <img src="@/assets/logos/datex-logo-rounded-light.svg" alt="DATEX" class="h-10 w-10 dark:hidden" />
-        <img src="@/assets/logos/datex-logo-rounded-dark.svg" alt="DATEX" class="h-10 w-10 hidden dark:block" />        <h1 class="text-3xl font-semibold tracking-tight text-foreground">
+        <IconLogo class="h-12 w-12" />
+       <h1 class="text-3xl font-semibold tracking-tight text-foreground">
           DATEX Workbench
         </h1>
       </div>


### PR DESCRIPTION
## Summary
Adds a landing/welcome screen for the DATEX Workbench at the `/` route, inspired by VS Code's welcome screen.

## Changes
- Replaced empty `WelcomeView.vue` placeholder with a full welcome screen
- Shows DATEX logo (light/dark mode aware)
- Quick action cards linking to:
  - Network Inspector (`/network`)
  - Node View (`/node-view`)
  - File Editor (`/editor`)
  - REPL (coming soon-> disabled with badge)
- Each card shows icon, title, description and arrow on hover
- Footer links to unyt.org, GitHub and Docs
- Fully supports light and dark mode

## How to test
1. Go to `http://localhost:5173/`
2. Should see the welcome screen with 4 cards
3. Click Network Inspector → navigates to `/network`
4. Click Node View → navigates to `/node-view`
5. Click File Editor → navigates to `/editor`
6. REPL card is disabled with "Soon" badge