### PR TITLE
feat: add about view with runtime info

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -57,6 +57,11 @@ const router = createRouter({
             name: 'repl',
             component: () => import('@/views/Repl/DatexRepl.vue'),
         },
+        {
+          path: '/about',
+          name: 'about',
+          component: () => import('@/views/AboutView.vue'),
+      },
     ],
 });
 

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { Datex } from '@/lib/runtime'
+</script>
+
+<template>
+  <div class="p-6 font-mono text-sm text-foreground">
+    <h1 class="text-lg font-semibold mb-4">About</h1>
+
+    <div class="mb-2">DATEX Version: {{ Datex.version }}</div>
+    <div class="mb-2">JS Version: {{ Datex.js_version }}</div>
+    <div class="mb-4">Endpoint: {{ Datex.endpoint }}</div>
+
+    <h2 class="text-md font-semibold mb-2">Active Features</h2>
+    <div class="text-muted-foreground italic">No features enabled</div>
+  </div>
+</template>

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -2,35 +2,36 @@
 import { Datex } from '@/lib/runtime'
 
 const features = ['Network Inspector', 'Block Viewer', 'Node View']
-
 </script>
 
 <template>
-  <div class="p-6 text-sm">
-    <h1 class="text-lg font-semibold mb-4 text-foreground">About</h1>
+  <div class="flex h-full w-full items-center justify-center p-6">
+    <div class="w-full max-w-xl rounded-xl bg-muted/30 p-8 text-sm">
+      <h1 class="text-lg font-semibold mb-4 text-foreground">About</h1>
 
-    <div class="mb-2">
-      <span class="text-foreground">DATEX Version: </span>
-      <span class="text-muted-foreground">{{ Datex.version }}</span>
-    </div>
-    <div class="mb-2">
-      <span class="text-foreground">JS Version: </span>
-      <span class="text-muted-foreground">{{ Datex.js_version }}</span>
-    </div>
-    <div class="mb-4">
-      <span class="text-foreground">Endpoint: </span>
-      <span class="text-muted-foreground">{{ Datex.endpoint }}</span>
-    </div>
+      <div class="mb-2">
+        <span class="text-foreground">DATEX Version: </span>
+        <span class="text-muted-foreground">{{ Datex.version }}</span>
+      </div>
+      <div class="mb-2">
+        <span class="text-foreground">JS Version: </span>
+        <span class="text-muted-foreground">{{ Datex.js_version }}</span>
+      </div>
+      <div class="mb-4">
+        <span class="text-foreground">Endpoint: </span>
+        <span class="text-muted-foreground">{{ Datex.endpoint }}</span>
+      </div>
 
-    <h2 class="text-md font-semibold mb-3 text-foreground">Active Features</h2>
-    <div class="flex flex-wrap gap-2">
-      <span
-        v-for="feature in features"
-        :key="feature"
-        class="rounded-full border border-border px-3 py-1 text-sm text-foreground shadow-sm"
-      >
-        {{ feature }}
-      </span>
+      <div class="flex flex-wrap items-center gap-2">
+        <span class="text-foreground font-semibold">Active Features:</span>
+        <span
+          v-for="feature in features"
+          :key="feature"
+          class="rounded-full border border-border px-2 py-0.5 text-xs text-foreground"
+        >
+          {{ feature }}
+        </span>
+      </div>
     </div>
-    </div>
+  </div>
 </template>

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -1,16 +1,36 @@
 <script setup lang="ts">
 import { Datex } from '@/lib/runtime'
+
+const features = ['Network Inspector', 'Block Viewer', 'Node View']
+
 </script>
 
 <template>
-  <div class="p-6 font-mono text-sm text-foreground">
-    <h1 class="text-lg font-semibold mb-4">About</h1>
+  <div class="p-6 text-sm">
+    <h1 class="text-lg font-semibold mb-4 text-foreground">About</h1>
 
-    <div class="mb-2">DATEX Version: {{ Datex.version }}</div>
-    <div class="mb-2">JS Version: {{ Datex.js_version }}</div>
-    <div class="mb-4">Endpoint: {{ Datex.endpoint }}</div>
+    <div class="mb-2">
+      <span class="text-foreground">DATEX Version: </span>
+      <span class="text-muted-foreground">{{ Datex.version }}</span>
+    </div>
+    <div class="mb-2">
+      <span class="text-foreground">JS Version: </span>
+      <span class="text-muted-foreground">{{ Datex.js_version }}</span>
+    </div>
+    <div class="mb-4">
+      <span class="text-foreground">Endpoint: </span>
+      <span class="text-muted-foreground">{{ Datex.endpoint }}</span>
+    </div>
 
-    <h2 class="text-md font-semibold mb-2">Active Features</h2>
-    <div class="text-muted-foreground italic">No features enabled</div>
-  </div>
+    <h2 class="text-md font-semibold mb-3 text-foreground">Active Features</h2>
+    <div class="flex flex-wrap gap-2">
+      <span
+        v-for="feature in features"
+        :key="feature"
+        class="rounded-full border border-border px-3 py-1 text-sm text-foreground shadow-sm"
+      >
+        {{ feature }}
+      </span>
+    </div>
+    </div>
 </template>


### PR DESCRIPTION
## feat: About View

Adds a new `/about` page displaying runtime information.

### What it shows
- DATEX runtime version (`Datex.version`)
- JS library version (`Datex.js_version`)
- Current endpoint (`Datex.endpoint`)
- Placeholder section for active features (empty for now)

### Files added
- `src/views/AboutView.vue`

### Files modified
- `src/router/index.ts` — added `/about` route