### PR TITLE
feat: Network Inspector Block Viewer

### DIFF
--- a/src/components/NetworkInspector/DataTable.vue
+++ b/src/components/NetworkInspector/DataTable.vue
@@ -33,6 +33,7 @@ const props = withDefaults(defineProps<DataTableProps>(), {
 
 const emit = defineEmits<{
   'load-more': []
+  'row-click': [row: Record<string, unknown>]
 }>()
 
 const sorting = ref<SortingState>([])
@@ -153,7 +154,8 @@ watch(() => props.filterValue, (val) => {
           <div
             v-for="virtualRow in virtualRows"
             :key="virtualRow.index"
-            class="flex absolute w-full border-b border-border hover:bg-accent"
+            class="flex absolute w-full border-b border-border hover:bg-accent cursor-pointer"
+            @click="emit('row-click', rows[virtualRow.index]?.original as Record<string, unknown>)"
             :style="{ transform: `translateY(${virtualRow.start}px)`, height: virtualRow.size + 'px' }"
           >
             <div

--- a/src/views/NetworkInspector/NetworkInspectorView.vue
+++ b/src/views/NetworkInspector/NetworkInspectorView.vue
@@ -21,8 +21,9 @@ import { useNetworkInspector } from '@/composable/useNetworkInspector';
 import DatexBlockProtocolView from '@/views/BlockViewer/DatexBlockProtocolView.vue';
 import type { NetworkBlockTableRow } from '@/types/NetworkInspector/TableRow';
 import { filterRowsBySearch, parseSearchQuery } from '@/utils/searchParser';
-import { Trash, X } from 'lucide-vue-next';
+import { Trash, X, Lock, Unlock } from 'lucide-vue-next';
 import { computed, nextTick, ref, watch } from 'vue';
+import type { RawBlockEntry } from '@/types/NetworkInspector/BlockEntry'
 
 const {
     sendTestBlock,
@@ -37,19 +38,21 @@ const {
 // Search query state
 const searchQuery = ref('');
 
+const selectedBlockEntry = ref<RawBlockEntry | null>(null)
+
 // Selected block for right panel
-const selectedBlock = ref<Uint8Array | null>(null)
+const selectedBlock = computed(() => selectedBlockEntry.value?.originalBinary ?? null)
 
 function onRowClick(row: Record<string, unknown>) {
   const capturedAt = row.capturedAt as number
   const block = blocks.value.find(b => b.capturedAt === capturedAt)
   if (block) {
-    selectedBlock.value = block.originalBinary
+    selectedBlockEntry.value = block
   }
 }
 
 function closeBlockViewer() {
-    selectedBlock.value = null;
+    selectedBlockEntry.value = null;
 }
 
 // Alert dialog state
@@ -172,6 +175,13 @@ const dynamicColumns = computed(() => {
     return createColumns(parsedQuery);
 });
 
+const isBlockSecure = computed(() => {
+  const entry = selectedBlockEntry.value
+  if (!entry) return false
+  return (entry.encryptionType !== 'None' && entry.encryptionType !== 'Unknown')
+    || (entry.signatureType !== 'None' && entry.signatureType !== 'Unknown')
+})
+
 </script>
 
 <template>
@@ -263,8 +273,14 @@ const dynamicColumns = computed(() => {
       <!-- Right panel: block viewer -->
       <div v-if="selectedBlock" class="w-1/2 flex flex-col h-full overflow-y-auto">
           <div class="flex items-center justify-between px-4 py-2 border-b border-border">
-              <span class="text-sm font-semibold text-foreground">Block Viewer</span>
-              <button
+            <div class="flex items-center gap-2 text-sm font-mono">
+  <span class="text-muted-foreground">[{{ selectedBlockEntry?.blockType }}]</span>
+  <span class="text-foreground">{{ selectedBlockEntry?.sender }}</span>
+  <span class="text-muted-foreground">→</span>
+  <span class="text-foreground">{{ selectedBlockEntry?.receivers.join(', ') }}</span>
+  <Lock v-if="isBlockSecure" class="size-3.5 text-muted-foreground" />
+  <Unlock v-else class="size-3.5 text-muted-foreground" />
+</div>              <button
                   class="text-muted-foreground hover:text-foreground transition"
                   @click="closeBlockViewer"
               >

--- a/src/views/NetworkInspector/NetworkInspectorView.vue
+++ b/src/views/NetworkInspector/NetworkInspectorView.vue
@@ -18,9 +18,10 @@ import {
 import { Button } from '@/components/ui/button';
 import { BLOCK_TYPES } from '@/composable/useBlockSimulator';
 import { useNetworkInspector } from '@/composable/useNetworkInspector';
+import DatexBlockProtocolView from '@/views/BlockViewer/DatexBlockProtocolView.vue';
 import type { NetworkBlockTableRow } from '@/types/NetworkInspector/TableRow';
 import { filterRowsBySearch, parseSearchQuery } from '@/utils/searchParser';
-import { Trash } from 'lucide-vue-next';
+import { Trash, X } from 'lucide-vue-next';
 import { computed, nextTick, ref, watch } from 'vue';
 
 const {
@@ -35,6 +36,21 @@ const {
 
 // Search query state
 const searchQuery = ref('');
+
+// Selected block for right panel
+const selectedBlock = ref<Uint8Array | null>(null)
+
+function onRowClick(row: Record<string, unknown>) {
+  const capturedAt = row.capturedAt as number
+  const block = blocks.value.find(b => b.capturedAt === capturedAt)
+  if (block) {
+    selectedBlock.value = block.originalBinary
+  }
+}
+
+function closeBlockViewer() {
+    selectedBlock.value = null;
+}
 
 // Alert dialog state
 const showDeleteDialog = ref(false);
@@ -155,88 +171,112 @@ const dynamicColumns = computed(() => {
     const parsedQuery = parseSearchQuery(searchQuery.value);
     return createColumns(parsedQuery);
 });
+
 </script>
 
 <template>
-    <div class="top-offset bg-background text-foreground flex h-full flex-col p-4">
-        <div class="mb-4">
-            <h1 class="mb-3 text-2xl font-bold">Network Inspector</h1>
+  <div class="top-offset bg-background text-foreground flex h-full">
+      <!-- Left panel: block list -->
+      <div class="flex flex-col p-4" :class="selectedBlock ? 'w-1/2 border-r border-border' : 'w-full'">
+          <div class="mb-4">
+              <h1 class="mb-3 text-2xl font-bold">Network Inspector</h1>
 
-            <!-- Block simulation buttons -->
-            <div class="flex flex-wrap gap-2">
-                <Button
-                    v-for="blockType in BLOCK_TYPES"
-                    :key="blockType.id"
-                    @click="sendTestBlock()"
-                    variant="outline"
-                    size="sm"
-                    class="text-foreground border-border"
-                    :title="blockType.description"
-                >
-                    {{ blockType.label }}
-                </Button>
+              <!-- Block simulation buttons -->
+              <div class="flex flex-wrap gap-2">
+                  <Button
+                      v-for="blockType in BLOCK_TYPES"
+                      :key="blockType.id"
+                      @click="sendTestBlock()"
+                      variant="outline"
+                      size="sm"
+                      class="text-foreground border-border"
+                      :title="blockType.description"
+                  >
+                      {{ blockType.label }}
+                  </Button>
 
-                <!-- Legacy TraceBack button -->
-                <Button
-                    @click="sendTestBlock"
-                    variant="outline"
-                    size="sm"
-                    class="text-foreground border-border"
-                    title="Legacy traceback block (base64 encoded)"
-                >
-                    TraceBack (Legacy)
-                </Button>
-            </div>
-        </div>
+                  <!-- Legacy TraceBack button -->
+                  <Button
+                      @click="sendTestBlock"
+                      variant="outline"
+                      size="sm"
+                      class="text-foreground border-border"
+                      title="Legacy traceback block (base64 encoded)"
+                  >
+                      TraceBack (Legacy)
+                  </Button>
+              </div>
+          </div>
 
-        <div ref="scrollContainerRef" class="max-h-[calc(100vh-200px)] flex-1 overflow-y-auto no-drag">
-            <DataTable
-                :columns="dynamicColumns"
-                :data="tableRows"
-                :has-more-data="hasMoreBlocks && !searchQuery.trim()"
-                @load-more="loadMoreBlocks"
-            >
-                <template #filter>
-                    <div class="flex items-center gap-2">
-                        <NetworkFilter
-                            v-model:filter-value="searchQuery"
-                            :suggestions="searchSuggestions"
-                            placeholder="Search: type:traceback sender:@sender"
-                        />
-                        <AlertDialog v-model:open="showDeleteDialog">
-                            <AlertDialogTrigger as-child>
-                                <Button
-                                    variant="outline"
-                                    size="icon"
-                                    title="Clear all displayed blocks"
-                                    class="text-foreground border-border transition-colors hover:text-red-600"
-                                    :disabled="blocks.length === 0"
-                                >
-                                    <Trash class="h-4 w-4" />
-                                </Button>
-                            </AlertDialogTrigger>
-                            <AlertDialogContent>
-                                <AlertDialogHeader>
-                                    <AlertDialogTitle>Delete Blocks?</AlertDialogTitle>
-                                    <AlertDialogDescription>
-                                        {{ deleteMessage }}
-                                        This action cannot be undone.
-                                    </AlertDialogDescription>
-                                </AlertDialogHeader>
-                                <AlertDialogFooter>
-                                    <AlertDialogCancel>Cancel</AlertDialogCancel>
-                                    <AlertDialogAction
-                                        @click="confirmClearBlocks"
-                                        class="bg-red-600 hover:bg-red-700"
-                                    >
-                                        Delete
-                                    </AlertDialogAction>
-                                </AlertDialogFooter>
-                            </AlertDialogContent>
-                        </AlertDialog>
-                    </div>
-                </template>
-            </DataTable>
-        </div>
-    </div>
+          <div ref="scrollContainerRef" class="flex-1 overflow-y-auto">
+              <DataTable
+                  :columns="dynamicColumns"
+                  :data="tableRows"
+                  :has-more-data="hasMoreBlocks && !searchQuery.trim()"
+                  @load-more="loadMoreBlocks"
+                  @row-click="onRowClick"
+              >
+                  <template #filter>
+                      <div class="flex items-center gap-2">
+                          <NetworkFilter
+                              v-model:filter-value="searchQuery"
+                              :suggestions="searchSuggestions"
+                              placeholder="Search: type:traceback sender:@sender"
+                          />
+                          <AlertDialog v-model:open="showDeleteDialog">
+                              <AlertDialogTrigger as-child>
+                                  <Button
+                                      variant="outline"
+                                      size="icon"
+                                      title="Clear all displayed blocks"
+                                      class="text-foreground border-border transition-colors hover:text-red-600"
+                                      :disabled="blocks.length === 0"
+                                  >
+                                      <Trash class="h-4 w-4" />
+                                  </Button>
+                              </AlertDialogTrigger>
+                              <AlertDialogContent>
+                                  <AlertDialogHeader>
+                                      <AlertDialogTitle>Delete Blocks?</AlertDialogTitle>
+                                      <AlertDialogDescription>
+                                          {{ deleteMessage }}
+                                          This action cannot be undone.
+                                      </AlertDialogDescription>
+                                  </AlertDialogHeader>
+                                  <AlertDialogFooter>
+                                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                      <AlertDialogAction
+                                          @click="confirmClearBlocks"
+                                          class="bg-red-600 hover:bg-red-700"
+                                      >
+                                          Delete
+                                      </AlertDialogAction>
+                                  </AlertDialogFooter>
+                              </AlertDialogContent>
+                          </AlertDialog>
+                      </div>
+                  </template>
+              </DataTable>
+          </div>
+      </div>
+
+      <!-- Right panel: block viewer -->
+      <div v-if="selectedBlock" class="w-1/2 flex flex-col h-full overflow-y-auto">
+          <div class="flex items-center justify-between px-4 py-2 border-b border-border">
+              <span class="text-sm font-semibold text-foreground">Block Viewer</span>
+              <button
+                  class="text-muted-foreground hover:text-foreground transition"
+                  @click="closeBlockViewer"
+              >
+                  <X class="size-4" />
+              </button>
+          </div>
+          <div class="flex-1 overflow-y-auto">
+              <DatexBlockProtocolView
+                  :blockData="selectedBlock"
+                  :key="selectedBlock.byteLength + '-' + Date.now()"
+              />
+          </div>
+      </div>
+  </div>
 </template>

--- a/src/views/NetworkInspector/NetworkInspectorView.vue
+++ b/src/views/NetworkInspector/NetworkInspectorView.vue
@@ -187,7 +187,7 @@ const isBlockSecure = computed(() => {
 <template>
   <div class="top-offset bg-background text-foreground flex h-full">
       <!-- Left panel: block list -->
-      <div class="flex flex-col p-4" :class="selectedBlock ? 'w-1/2 border-r border-border' : 'w-full'">
+      <div class="flex flex-col p-4 pt-0" :class="selectedBlock ? 'w-1/2 border-r border-border' : 'w-full'">
           <div class="mb-4">
               <h1 class="mb-3 text-2xl font-bold">Network Inspector</h1>
 
@@ -274,12 +274,12 @@ const isBlockSecure = computed(() => {
       <div v-if="selectedBlock" class="w-1/2 flex flex-col h-full overflow-y-auto">
           <div class="flex items-center justify-between px-4 py-2 border-b border-border">
             <div class="flex items-center gap-2 text-sm font-mono">
-  <span class="text-muted-foreground">[{{ selectedBlockEntry?.blockType }}]</span>
-  <span class="text-foreground">{{ selectedBlockEntry?.sender }}</span>
+  <span class="text-muted-foreground uppercase">{{ selectedBlockEntry?.blockType }}</span>
+      <Lock v-if="isBlockSecure" class="size-3.5 text-muted-foreground" />
+    <Unlock v-else class="size-3.5 text-muted-foreground" />
+  <span class="text-foreground pl-3">{{ selectedBlockEntry?.sender }}</span>
   <span class="text-muted-foreground">→</span>
   <span class="text-foreground">{{ selectedBlockEntry?.receivers.join(', ') }}</span>
-  <Lock v-if="isBlockSecure" class="size-3.5 text-muted-foreground" />
-  <Unlock v-else class="size-3.5 text-muted-foreground" />
 </div>              <button
                   class="text-muted-foreground hover:text-foreground transition"
                   @click="closeBlockViewer"


### PR DESCRIPTION
## feat: show block viewer on right side when clicking network inspector…

Adds a split-panel block viewer to the Network Inspector (`/network`).

### What it does
When clicking a row in the network block list, a Block Viewer panel opens on the right side showing the full parsed block (Routing Header, Block Header, Encrypted Header, Body), same view as `/block`.

### Features
- Click any row to view the block details on the right
- Close button (X) to dismiss the viewer
- Left panel resizes to 50% when viewer is open, full width when closed
- Clicking a different row updates the viewer

### Files modified
- `src/views/NetworkInspector/NetworkInspectorView.vue`: split layout with block viewer panel
- `src/components/NetworkInspector/DataTable.vue`: added `row-click` emit