### PR TITLE
feat: i18n with vue-i18n, language switcher (en/de/hi), translate Wel…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "tailwindcss": "^4.1.16",
         "tw-animate-css": "^1.4.0",
         "vue": "^3.5.22",
+        "vue-i18n": "^11.4.0",
         "vue-router": "^4.6.3"
       },
       "devDependencies": {
@@ -3070,6 +3071,67 @@
         "@swc/helpers": "^0.5.0"
       }
     },
+    "node_modules/@intlify/core-base": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.4.0.tgz",
+      "integrity": "sha512-nlxFOnmjJgVkL1PsuSMagyh3qIHTwc2KlO2R3qQQV1ydrcwh1XpM7opWUGqvGaLlktttopDzbLBpr/k5tvbNmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/devtools-types": "11.4.0",
+        "@intlify/message-compiler": "11.4.0",
+        "@intlify/shared": "11.4.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/devtools-types": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@intlify/devtools-types/-/devtools-types-11.4.0.tgz",
+      "integrity": "sha512-LtQ04kG8/2Nv6AbuINpkjODuhKHdd+MGLlXKW3I0GTCeDsDIBZUot82nnyK7D6+qersF08FqSvoN/eGPcL3c7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "11.4.0",
+        "@intlify/shared": "11.4.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.4.0.tgz",
+      "integrity": "sha512-v455gVZqMb0er63Wd/akX8DXTnwSubgrgQaRigLB60V3xpnq3B99oPvGXW+N4G/5QFt8Ls84FJ8qHJUVnRCs1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "11.4.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.4.0.tgz",
+      "integrity": "sha512-r9qUeLeO0TMZmUZ+mXS6IGQ6xwzZJaVMK6j4CdoA3eQP8xp3JtCfwkZ30gB4+knlN40pmBdDXgx85SWhMCzHng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -3533,9 +3595,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3548,9 +3607,6 @@
       "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3565,9 +3621,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3580,9 +3633,6 @@
       "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3597,9 +3647,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3612,9 +3659,6 @@
       "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3629,9 +3673,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3644,9 +3685,6 @@
       "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3661,9 +3699,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3677,9 +3712,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3692,9 +3724,6 @@
       "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3981,9 +4010,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3999,9 +4025,6 @@
       "integrity": "sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9249,9 +9272,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9271,9 +9291,6 @@
       "integrity": "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -13321,6 +13338,27 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/vue-i18n": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.4.0.tgz",
+      "integrity": "sha512-gxLVtcwdvOgwKSzkdb7nHKlW0N85A6aDNmHLnq6V+3w2/BXy/os5l71P7TIlgIQTxX0zJjiz89iImoHi51GieQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "11.4.0",
+        "@intlify/devtools-types": "11.4.0",
+        "@intlify/shared": "11.4.0",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/vue-router": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "tailwindcss": "^4.1.16",
     "tw-animate-css": "^1.4.0",
     "vue": "^3.5.22",
+    "vue-i18n": "^11.4.0",
     "vue-router": "^4.6.3"
   },
   "devDependencies": {

--- a/src/components/HeaderProvider.vue
+++ b/src/components/HeaderProvider.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { useRoute } from 'vue-router'
 import ThemeSwitch from '@/components/ThemeSwitch.vue';
+import LanguageSwitcher from '@/components/LanguageSwitcher.vue';
 import IconLogo from '@/components/icons/IconLogo.vue';
 import {
     Menubar,
@@ -24,7 +25,7 @@ export default {
         // MenubarMenu,
         Menubar,
         IconLogo,
-        ThemeSwitch },
+        ThemeSwitch, LanguageSwitcher },
         setup() {
     const route = useRoute()
     return { route }
@@ -82,7 +83,8 @@ export default {
                 <MenubarItem>Hide / Expand Sidebar</MenubarItem>
             </MenubarContent>
         </MenubarMenu>-->
-        <div class="ml-auto">
+        <div class="ml-auto flex items-center gap-2">
+          <LanguageSwitcher />
             <ThemeSwitch />
         </div>
     </Menubar>

--- a/src/components/LanguageSwitcher.vue
+++ b/src/components/LanguageSwitcher.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Languages, Check } from 'lucide-vue-next'
+import { SUPPORTED_LOCALES, setLocale, type LocaleCode } from '@/i18n'
+
+const { locale } = useI18n()
+const isOpen = ref(false)
+
+const currentLabel = computed(
+  () => SUPPORTED_LOCALES.find(l => l.code === locale.value)?.label ?? 'English'
+)
+
+function selectLocale(code: LocaleCode) {
+  setLocale(code)
+  isOpen.value = false
+}
+
+function toggleMenu() {
+  isOpen.value = !isOpen.value
+}
+
+function handleClickOutside(event: MouseEvent) {
+  const target = event.target as HTMLElement
+  if (!target.closest('.lang-switcher')) {
+    isOpen.value = false
+  }
+}
+
+import { onMounted, onUnmounted } from 'vue'
+onMounted(() => document.addEventListener('mousedown', handleClickOutside))
+onUnmounted(() => document.removeEventListener('mousedown', handleClickOutside))
+</script>
+
+<template>
+  <div class="lang-switcher relative">
+    <button
+      class="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-xs text-foreground hover:bg-muted transition"
+      @click="toggleMenu"
+    >
+      <Languages class="size-3.5" />
+      {{ currentLabel }}
+    </button>
+
+    <div
+      v-if="isOpen"
+      class="absolute right-0 top-full mt-1 z-50 min-w-32 rounded-md border border-border bg-popover shadow-md py-1"
+    >
+      <button
+        v-for="lang in SUPPORTED_LOCALES"
+        :key="lang.code"
+        class="flex w-full items-center justify-between px-3 py-1.5 text-xs text-foreground hover:bg-muted transition"
+        @click="selectLocale(lang.code)"
+      >
+        <span>{{ lang.label }}</span>
+        <Check v-if="locale === lang.code" class="size-3.5 text-primary" />
+      </button>
+    </div>
+  </div>
+</template>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,40 @@
+import { createI18n } from 'vue-i18n'
+import en from './locales/en.json'
+import de from './locales/de.json'
+import hi from './locales/hi.json'
+
+export const SUPPORTED_LOCALES = [
+  { code: 'en', label: 'English' },
+  { code: 'de', label: 'Deutsch' },
+  { code: 'hi', label: 'हिन्दी' },
+] as const
+
+export type LocaleCode = typeof SUPPORTED_LOCALES[number]['code']
+
+const STORAGE_KEY = 'datex-workbench-locale'
+
+function getInitialLocale(): LocaleCode {
+  const stored = localStorage.getItem(STORAGE_KEY) as LocaleCode | null
+  if (stored && SUPPORTED_LOCALES.some(l => l.code === stored)) {
+    return stored
+  }
+  // Try browser language
+  const browserLang = navigator.language.slice(0, 2) as LocaleCode
+  if (SUPPORTED_LOCALES.some(l => l.code === browserLang)) {
+    return browserLang
+  }
+  return 'en'
+}
+
+export const i18n = createI18n({
+  legacy: false,
+  locale: getInitialLocale(),
+  fallbackLocale: 'en',
+  messages: { en, de, hi },
+})
+
+export function setLocale(locale: LocaleCode) {
+  i18n.global.locale.value = locale
+  localStorage.setItem(STORAGE_KEY, locale)
+  document.documentElement.lang = locale
+}

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1,0 +1,86 @@
+{
+    "welcome": {
+  "subtitle": "Entwicklungstools für die DATEX-Laufzeit",
+  "quickActions": "Schnellaktionen",
+  "networkDesc": "DATEX-Netzwerkblöcke in Echtzeit überwachen und untersuchen",
+  "nodeDesc": "Den DATEX-Knotengraphen visualisieren und bearbeiten",
+  "editorDesc": "DATEX-Dateien direkt in der Workbench bearbeiten",
+  "replDesc": "Interaktive DATEX-Laufzeitumgebung",
+  "soon": "Bald",
+  "fileEditor": "Datei-Editor",
+  "repl": "REPL"
+},
+    "common": {
+      "loading": "Lädt...",
+      "save": "Speichern",
+      "cancel": "Abbrechen",
+      "delete": "Löschen",
+      "close": "Schließen",
+      "open": "Öffnen",
+      "search": "Suchen",
+      "settings": "Einstellungen",
+      "language": "Sprache"
+    },
+    "nav": {
+      "block": "Block",
+      "network": "Netzwerk",
+      "nodeView": "Knotenansicht",
+      "networkTree": "Netzwerk-Baum",
+      "collection": "Sammlung",
+      "about": "Über"
+    },
+    "block": {
+      "openFile": "Datei öffnen",
+      "saveBin": ".bin speichern",
+      "dropHint": "Eine .bin-Datei hier ablegen oder „Datei öffnen“ klicken",
+      "dropOverlay": ".bin-Datei hier ablegen",
+      "loadExample": "Beispielblock laden",
+      "fileEmpty": "Datei ist leer",
+      "invalidBlock": "Ungültiger DXB-Block — Magic Number stimmt nicht überein"
+    },
+    "disassembler": {
+      "disassembler": "DISASSEMBLER",
+      "decompiler": "DEKOMPILIERER",
+      "tree": "Baum",
+      "flat": "Flach",
+      "nested": "Verschachtelt",
+      "noInstructions": "Keine Anweisungen zum Anzeigen"
+    },
+    "network": {
+      "title": "Netzwerk-Inspektor",
+      "blockViewer": "Block-Anzeige",
+      "deleteBlocks": "Blöcke löschen?",
+      "deleteConfirm": "Diese Aktion kann nicht rückgängig gemacht werden.",
+      "clearAll": "Alle angezeigten Blöcke löschen"
+    },
+    "trace": {
+      "endpoint": "@endpunkt",
+      "timeout": "Zeitüberschreitung (ms)",
+      "trace": "Verfolgen",
+      "tracing": "Verfolgt...",
+      "autoTrace": "Auto-Verfolgen",
+      "autoTracing": "Auto-Verfolgt...",
+      "endpointUnreachable": "Endpunkt nicht erreichbar",
+      "tracePlaceholder": "Sende eine Verfolgung, um den Netzwerkpfad zu visualisieren"
+    },
+    "collection": {
+      "title": "Sammlung",
+      "id": "ID",
+      "name": "Name",
+      "age": "Alter",
+      "admin": "Admin",
+      "registered": "Registriert",
+      "yes": "Ja",
+      "no": "Nein",
+      "showing": "Zeige {from}–{to} von {total} Einträgen",
+      "previous": "Zurück",
+      "next": "Weiter"
+    },
+    "about": {
+      "title": "Über",
+      "datexVersion": "DATEX-Version",
+      "jsVersion": "JS-Version",
+      "endpoint": "Endpunkt",
+      "activeFeatures": "Aktive Funktionen"
+    }
+  }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1,86 +1,86 @@
 {
     "welcome": {
-  "subtitle": "Entwicklungstools für die DATEX-Laufzeit",
-  "quickActions": "Schnellaktionen",
-  "networkDesc": "DATEX-Netzwerkblöcke in Echtzeit überwachen und untersuchen",
-  "nodeDesc": "Den DATEX-Knotengraphen visualisieren und bearbeiten",
-  "editorDesc": "DATEX-Dateien direkt in der Workbench bearbeiten",
-  "replDesc": "Interaktive DATEX-Laufzeitumgebung",
-  "soon": "Bald",
-  "fileEditor": "Datei-Editor",
-  "repl": "REPL"
-},
+        "subtitle": "Entwicklungstools für die DATEX-Laufzeit",
+        "quickActions": "Schnellaktionen",
+        "networkDesc": "DATEX-Netzwerkblöcke in Echtzeit überwachen und untersuchen",
+        "nodeDesc": "Den DATEX-Knotengraphen visualisieren und bearbeiten",
+        "editorDesc": "DATEX-Dateien direkt in der Workbench bearbeiten",
+        "replDesc": "Interaktive DATEX-Laufzeitumgebung",
+        "soon": "Bald",
+        "fileEditor": "Datei-Editor",
+        "repl": "REPL"
+    },
     "common": {
-      "loading": "Lädt...",
-      "save": "Speichern",
-      "cancel": "Abbrechen",
-      "delete": "Löschen",
-      "close": "Schließen",
-      "open": "Öffnen",
-      "search": "Suchen",
-      "settings": "Einstellungen",
-      "language": "Sprache"
+        "loading": "Lädt...",
+        "save": "Speichern",
+        "cancel": "Abbrechen",
+        "delete": "Löschen",
+        "close": "Schließen",
+        "open": "Öffnen",
+        "search": "Suchen",
+        "settings": "Einstellungen",
+        "language": "Sprache"
     },
     "nav": {
-      "block": "Block",
-      "network": "Netzwerk",
-      "nodeView": "Knotenansicht",
-      "networkTree": "Netzwerk-Baum",
-      "collection": "Sammlung",
-      "about": "Über"
+        "block": "Block",
+        "network": "Netzwerk",
+        "nodeView": "Knotenansicht",
+        "networkTree": "Netzwerk-Baum",
+        "collection": "Sammlung",
+        "about": "Über"
     },
     "block": {
-      "openFile": "Datei öffnen",
-      "saveBin": ".bin speichern",
-      "dropHint": "Eine .bin-Datei hier ablegen oder „Datei öffnen“ klicken",
-      "dropOverlay": ".bin-Datei hier ablegen",
-      "loadExample": "Beispielblock laden",
-      "fileEmpty": "Datei ist leer",
-      "invalidBlock": "Ungültiger DXB-Block — Magic Number stimmt nicht überein"
+        "openFile": "Datei öffnen",
+        "saveBin": ".bin speichern",
+        "dropHint": "Eine .bin-Datei hier ablegen oder „Datei öffnen“ klicken",
+        "dropOverlay": ".bin-Datei hier ablegen",
+        "loadExample": "Beispielblock laden",
+        "fileEmpty": "Datei ist leer",
+        "invalidBlock": "Ungültiger DXB-Block — Magic Number stimmt nicht überein"
     },
     "disassembler": {
-      "disassembler": "DISASSEMBLER",
-      "decompiler": "DEKOMPILIERER",
-      "tree": "Baum",
-      "flat": "Flach",
-      "nested": "Verschachtelt",
-      "noInstructions": "Keine Anweisungen zum Anzeigen"
+        "disassembler": "DISASSEMBLER",
+        "decompiler": "DEKOMPILIERER",
+        "tree": "Baum",
+        "flat": "Flach",
+        "nested": "Verschachtelt",
+        "noInstructions": "Keine Anweisungen zum Anzeigen"
     },
     "network": {
-      "title": "Netzwerk-Inspektor",
-      "blockViewer": "Block-Anzeige",
-      "deleteBlocks": "Blöcke löschen?",
-      "deleteConfirm": "Diese Aktion kann nicht rückgängig gemacht werden.",
-      "clearAll": "Alle angezeigten Blöcke löschen"
+        "title": "Netzwerk-Inspektor",
+        "blockViewer": "Block-Anzeige",
+        "deleteBlocks": "Blöcke löschen?",
+        "deleteConfirm": "Diese Aktion kann nicht rückgängig gemacht werden.",
+        "clearAll": "Alle angezeigten Blöcke löschen"
     },
     "trace": {
-      "endpoint": "@endpunkt",
-      "timeout": "Zeitüberschreitung (ms)",
-      "trace": "Verfolgen",
-      "tracing": "Verfolgt...",
-      "autoTrace": "Auto-Verfolgen",
-      "autoTracing": "Auto-Verfolgt...",
-      "endpointUnreachable": "Endpunkt nicht erreichbar",
-      "tracePlaceholder": "Sende eine Verfolgung, um den Netzwerkpfad zu visualisieren"
+        "endpoint": "@endpunkt",
+        "timeout": "Zeitüberschreitung (ms)",
+        "trace": "Verfolgen",
+        "tracing": "Verfolgt...",
+        "autoTrace": "Auto-Verfolgen",
+        "autoTracing": "Auto-Verfolgt...",
+        "endpointUnreachable": "Endpunkt nicht erreichbar",
+        "tracePlaceholder": "Sende eine Verfolgung, um den Netzwerkpfad zu visualisieren"
     },
     "collection": {
-      "title": "Sammlung",
-      "id": "ID",
-      "name": "Name",
-      "age": "Alter",
-      "admin": "Admin",
-      "registered": "Registriert",
-      "yes": "Ja",
-      "no": "Nein",
-      "showing": "Zeige {from}–{to} von {total} Einträgen",
-      "previous": "Zurück",
-      "next": "Weiter"
+        "title": "Sammlung",
+        "id": "ID",
+        "name": "Name",
+        "age": "Alter",
+        "admin": "Admin",
+        "registered": "Registriert",
+        "yes": "Ja",
+        "no": "Nein",
+        "showing": "Zeige {from}–{to} von {total} Einträgen",
+        "previous": "Zurück",
+        "next": "Weiter"
     },
     "about": {
-      "title": "Über",
-      "datexVersion": "DATEX-Version",
-      "jsVersion": "JS-Version",
-      "endpoint": "Endpunkt",
-      "activeFeatures": "Aktive Funktionen"
+        "title": "Über",
+        "datexVersion": "DATEX-Version",
+        "jsVersion": "JS-Version",
+        "endpoint": "Endpunkt",
+        "activeFeatures": "Aktive Funktionen"
     }
-  }
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,86 @@
+{
+    "welcome": {
+  "subtitle": "Developer tooling for the DATEX runtime",
+  "quickActions": "Quick Actions",
+  "networkDesc": "Monitor and inspect DATEX network blocks in real time",
+  "nodeDesc": "Visualize and edit the DATEX node graph",
+  "editorDesc": "Edit DATEX files directly in the workbench",
+  "replDesc": "Interactive DATEX runtime environment",
+  "soon": "Soon",
+  "fileEditor": "File Editor",
+  "repl": "REPL"
+},
+    "common": {
+      "loading": "Loading...",
+      "save": "Save",
+      "cancel": "Cancel",
+      "delete": "Delete",
+      "close": "Close",
+      "open": "Open",
+      "search": "Search",
+      "settings": "Settings",
+      "language": "Language"
+    },
+    "nav": {
+      "block": "Block",
+      "network": "Network",
+      "nodeView": "Node View",
+      "networkTree": "Network Tree",
+      "collection": "Collection",
+      "about": "About"
+    },
+    "block": {
+      "openFile": "Open File",
+      "saveBin": "Save .bin",
+      "dropHint": "Drop a .bin file here or click \"Open File\"",
+      "dropOverlay": "Drop .bin file here",
+      "loadExample": "Load example block",
+      "fileEmpty": "File is empty",
+      "invalidBlock": "Invalid DXB block — magic number mismatch"
+    },
+    "disassembler": {
+      "disassembler": "DISASSEMBLER",
+      "decompiler": "DECOMPILER",
+      "tree": "Tree",
+      "flat": "Flat",
+      "nested": "Nested",
+      "noInstructions": "No instructions to display"
+    },
+    "network": {
+      "title": "Network Inspector",
+      "blockViewer": "Block Viewer",
+      "deleteBlocks": "Delete Blocks?",
+      "deleteConfirm": "This action cannot be undone.",
+      "clearAll": "Clear all displayed blocks"
+    },
+    "trace": {
+      "endpoint": "@endpoint",
+      "timeout": "Timeout (ms)",
+      "trace": "Trace",
+      "tracing": "Tracing...",
+      "autoTrace": "Auto-Trace",
+      "autoTracing": "Auto-Tracing...",
+      "endpointUnreachable": "Endpoint not reachable",
+      "tracePlaceholder": "Send a trace to visualize the network path"
+    },
+    "collection": {
+      "title": "Collection",
+      "id": "ID",
+      "name": "Name",
+      "age": "Age",
+      "admin": "Admin",
+      "registered": "Registered",
+      "yes": "Yes",
+      "no": "No",
+      "showing": "Showing {from}–{to} of {total} entries",
+      "previous": "Previous",
+      "next": "Next"
+    },
+    "about": {
+      "title": "About",
+      "datexVersion": "DATEX Version",
+      "jsVersion": "JS Version",
+      "endpoint": "Endpoint",
+      "activeFeatures": "Active Features"
+    }
+  }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,86 +1,86 @@
 {
     "welcome": {
-  "subtitle": "Developer tooling for the DATEX runtime",
-  "quickActions": "Quick Actions",
-  "networkDesc": "Monitor and inspect DATEX network blocks in real time",
-  "nodeDesc": "Visualize and edit the DATEX node graph",
-  "editorDesc": "Edit DATEX files directly in the workbench",
-  "replDesc": "Interactive DATEX runtime environment",
-  "soon": "Soon",
-  "fileEditor": "File Editor",
-  "repl": "REPL"
-},
+        "subtitle": "Developer tooling for the DATEX runtime",
+        "quickActions": "Quick Actions",
+        "networkDesc": "Monitor and inspect DATEX network blocks in real time",
+        "nodeDesc": "Visualize and edit the DATEX node graph",
+        "editorDesc": "Edit DATEX files directly in the workbench",
+        "replDesc": "Interactive DATEX runtime environment",
+        "soon": "Soon",
+        "fileEditor": "File Editor",
+        "repl": "REPL"
+    },
     "common": {
-      "loading": "Loading...",
-      "save": "Save",
-      "cancel": "Cancel",
-      "delete": "Delete",
-      "close": "Close",
-      "open": "Open",
-      "search": "Search",
-      "settings": "Settings",
-      "language": "Language"
+        "loading": "Loading...",
+        "save": "Save",
+        "cancel": "Cancel",
+        "delete": "Delete",
+        "close": "Close",
+        "open": "Open",
+        "search": "Search",
+        "settings": "Settings",
+        "language": "Language"
     },
     "nav": {
-      "block": "Block",
-      "network": "Network",
-      "nodeView": "Node View",
-      "networkTree": "Network Tree",
-      "collection": "Collection",
-      "about": "About"
+        "block": "Block",
+        "network": "Network",
+        "nodeView": "Node View",
+        "networkTree": "Network Tree",
+        "collection": "Collection",
+        "about": "About"
     },
     "block": {
-      "openFile": "Open File",
-      "saveBin": "Save .bin",
-      "dropHint": "Drop a .bin file here or click \"Open File\"",
-      "dropOverlay": "Drop .bin file here",
-      "loadExample": "Load example block",
-      "fileEmpty": "File is empty",
-      "invalidBlock": "Invalid DXB block — magic number mismatch"
+        "openFile": "Open File",
+        "saveBin": "Save .bin",
+        "dropHint": "Drop a .bin file here or click \"Open File\"",
+        "dropOverlay": "Drop .bin file here",
+        "loadExample": "Load example block",
+        "fileEmpty": "File is empty",
+        "invalidBlock": "Invalid DXB block — magic number mismatch"
     },
     "disassembler": {
-      "disassembler": "DISASSEMBLER",
-      "decompiler": "DECOMPILER",
-      "tree": "Tree",
-      "flat": "Flat",
-      "nested": "Nested",
-      "noInstructions": "No instructions to display"
+        "disassembler": "DISASSEMBLER",
+        "decompiler": "DECOMPILER",
+        "tree": "Tree",
+        "flat": "Flat",
+        "nested": "Nested",
+        "noInstructions": "No instructions to display"
     },
     "network": {
-      "title": "Network Inspector",
-      "blockViewer": "Block Viewer",
-      "deleteBlocks": "Delete Blocks?",
-      "deleteConfirm": "This action cannot be undone.",
-      "clearAll": "Clear all displayed blocks"
+        "title": "Network Inspector",
+        "blockViewer": "Block Viewer",
+        "deleteBlocks": "Delete Blocks?",
+        "deleteConfirm": "This action cannot be undone.",
+        "clearAll": "Clear all displayed blocks"
     },
     "trace": {
-      "endpoint": "@endpoint",
-      "timeout": "Timeout (ms)",
-      "trace": "Trace",
-      "tracing": "Tracing...",
-      "autoTrace": "Auto-Trace",
-      "autoTracing": "Auto-Tracing...",
-      "endpointUnreachable": "Endpoint not reachable",
-      "tracePlaceholder": "Send a trace to visualize the network path"
+        "endpoint": "@endpoint",
+        "timeout": "Timeout (ms)",
+        "trace": "Trace",
+        "tracing": "Tracing...",
+        "autoTrace": "Auto-Trace",
+        "autoTracing": "Auto-Tracing...",
+        "endpointUnreachable": "Endpoint not reachable",
+        "tracePlaceholder": "Send a trace to visualize the network path"
     },
     "collection": {
-      "title": "Collection",
-      "id": "ID",
-      "name": "Name",
-      "age": "Age",
-      "admin": "Admin",
-      "registered": "Registered",
-      "yes": "Yes",
-      "no": "No",
-      "showing": "Showing {from}–{to} of {total} entries",
-      "previous": "Previous",
-      "next": "Next"
+        "title": "Collection",
+        "id": "ID",
+        "name": "Name",
+        "age": "Age",
+        "admin": "Admin",
+        "registered": "Registered",
+        "yes": "Yes",
+        "no": "No",
+        "showing": "Showing {from}–{to} of {total} entries",
+        "previous": "Previous",
+        "next": "Next"
     },
     "about": {
-      "title": "About",
-      "datexVersion": "DATEX Version",
-      "jsVersion": "JS Version",
-      "endpoint": "Endpoint",
-      "activeFeatures": "Active Features"
+        "title": "About",
+        "datexVersion": "DATEX Version",
+        "jsVersion": "JS Version",
+        "endpoint": "Endpoint",
+        "activeFeatures": "Active Features"
     }
-  }
+}

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -1,86 +1,86 @@
 {
     "welcome": {
-  "subtitle": "DATEX रनटाइम के लिए डेवलपर टूलिंग",
-  "quickActions": "त्वरित क्रियाएं",
-  "networkDesc": "रीयल टाइम में DATEX नेटवर्क ब्लॉक की निगरानी करें",
-  "nodeDesc": "DATEX नोड ग्राफ़ देखें और संपादित करें",
-  "editorDesc": "वर्कबेंच में DATEX फ़ाइलें संपादित करें",
-  "replDesc": "इंटरैक्टिव DATEX रनटाइम वातावरण",
-  "soon": "जल्द ही",
-  "fileEditor": "फ़ाइल संपादक",
-  "repl": "REPL"
-},
+        "subtitle": "DATEX रनटाइम के लिए डेवलपर टूलिंग",
+        "quickActions": "त्वरित क्रियाएं",
+        "networkDesc": "रीयल टाइम में DATEX नेटवर्क ब्लॉक की निगरानी करें",
+        "nodeDesc": "DATEX नोड ग्राफ़ देखें और संपादित करें",
+        "editorDesc": "वर्कबेंच में DATEX फ़ाइलें संपादित करें",
+        "replDesc": "इंटरैक्टिव DATEX रनटाइम वातावरण",
+        "soon": "जल्द ही",
+        "fileEditor": "फ़ाइल संपादक",
+        "repl": "REPL"
+    },
     "common": {
-      "loading": "लोड हो रहा है...",
-      "save": "सहेजें",
-      "cancel": "रद्द करें",
-      "delete": "हटाएं",
-      "close": "बंद करें",
-      "open": "खोलें",
-      "search": "खोजें",
-      "settings": "सेटिंग्स",
-      "language": "भाषा"
+        "loading": "लोड हो रहा है...",
+        "save": "सहेजें",
+        "cancel": "रद्द करें",
+        "delete": "हटाएं",
+        "close": "बंद करें",
+        "open": "खोलें",
+        "search": "खोजें",
+        "settings": "सेटिंग्स",
+        "language": "भाषा"
     },
     "nav": {
-      "block": "ब्लॉक",
-      "network": "नेटवर्क",
-      "nodeView": "नोड दृश्य",
-      "networkTree": "नेटवर्क ट्री",
-      "collection": "संग्रह",
-      "about": "बारे में"
+        "block": "ब्लॉक",
+        "network": "नेटवर्क",
+        "nodeView": "नोड दृश्य",
+        "networkTree": "नेटवर्क ट्री",
+        "collection": "संग्रह",
+        "about": "बारे में"
     },
     "block": {
-      "openFile": "फ़ाइल खोलें",
-      "saveBin": ".bin सहेजें",
-      "dropHint": "एक .bin फ़ाइल यहाँ छोड़ें या \"फ़ाइल खोलें\" क्लिक करें",
-      "dropOverlay": ".bin फ़ाइल यहाँ छोड़ें",
-      "loadExample": "उदाहरण ब्लॉक लोड करें",
-      "fileEmpty": "फ़ाइल खाली है",
-      "invalidBlock": "अमान्य DXB ब्लॉक — मैजिक नंबर मेल नहीं खाता"
+        "openFile": "फ़ाइल खोलें",
+        "saveBin": ".bin सहेजें",
+        "dropHint": "एक .bin फ़ाइल यहाँ छोड़ें या \"फ़ाइल खोलें\" क्लिक करें",
+        "dropOverlay": ".bin फ़ाइल यहाँ छोड़ें",
+        "loadExample": "उदाहरण ब्लॉक लोड करें",
+        "fileEmpty": "फ़ाइल खाली है",
+        "invalidBlock": "अमान्य DXB ब्लॉक — मैजिक नंबर मेल नहीं खाता"
     },
     "disassembler": {
-      "disassembler": "डिसअसेंबलर",
-      "decompiler": "डीकंपाइलर",
-      "tree": "ट्री",
-      "flat": "सपाट",
-      "nested": "नेस्टेड",
-      "noInstructions": "दिखाने के लिए कोई निर्देश नहीं"
+        "disassembler": "डिसअसेंबलर",
+        "decompiler": "डीकंपाइलर",
+        "tree": "ट्री",
+        "flat": "सपाट",
+        "nested": "नेस्टेड",
+        "noInstructions": "दिखाने के लिए कोई निर्देश नहीं"
     },
     "network": {
-      "title": "नेटवर्क इंस्पेक्टर",
-      "blockViewer": "ब्लॉक व्यूअर",
-      "deleteBlocks": "ब्लॉक हटाएं?",
-      "deleteConfirm": "यह क्रिया पूर्ववत नहीं की जा सकती।",
-      "clearAll": "सभी प्रदर्शित ब्लॉक साफ़ करें"
+        "title": "नेटवर्क इंस्पेक्टर",
+        "blockViewer": "ब्लॉक व्यूअर",
+        "deleteBlocks": "ब्लॉक हटाएं?",
+        "deleteConfirm": "यह क्रिया पूर्ववत नहीं की जा सकती।",
+        "clearAll": "सभी प्रदर्शित ब्लॉक साफ़ करें"
     },
     "trace": {
-      "endpoint": "@एंडपॉइंट",
-      "timeout": "टाइमआउट (ms)",
-      "trace": "ट्रेस",
-      "tracing": "ट्रेस कर रहा है...",
-      "autoTrace": "ऑटो-ट्रेस",
-      "autoTracing": "ऑटो-ट्रेस कर रहा है...",
-      "endpointUnreachable": "एंडपॉइंट तक नहीं पहुँचा जा सकता",
-      "tracePlaceholder": "नेटवर्क पथ देखने के लिए एक ट्रेस भेजें"
+        "endpoint": "@एंडपॉइंट",
+        "timeout": "टाइमआउट (ms)",
+        "trace": "ट्रेस",
+        "tracing": "ट्रेस कर रहा है...",
+        "autoTrace": "ऑटो-ट्रेस",
+        "autoTracing": "ऑटो-ट्रेस कर रहा है...",
+        "endpointUnreachable": "एंडपॉइंट तक नहीं पहुँचा जा सकता",
+        "tracePlaceholder": "नेटवर्क पथ देखने के लिए एक ट्रेस भेजें"
     },
     "collection": {
-      "title": "संग्रह",
-      "id": "आईडी",
-      "name": "नाम",
-      "age": "आयु",
-      "admin": "एडमिन",
-      "registered": "पंजीकृत",
-      "yes": "हाँ",
-      "no": "नहीं",
-      "showing": "{total} में से {from}–{to} दिखा रहा है",
-      "previous": "पिछला",
-      "next": "अगला"
+        "title": "संग्रह",
+        "id": "आईडी",
+        "name": "नाम",
+        "age": "आयु",
+        "admin": "एडमिन",
+        "registered": "पंजीकृत",
+        "yes": "हाँ",
+        "no": "नहीं",
+        "showing": "{total} में से {from}–{to} दिखा रहा है",
+        "previous": "पिछला",
+        "next": "अगला"
     },
     "about": {
-      "title": "बारे में",
-      "datexVersion": "DATEX संस्करण",
-      "jsVersion": "JS संस्करण",
-      "endpoint": "एंडपॉइंट",
-      "activeFeatures": "सक्रिय सुविधाएँ"
+        "title": "बारे में",
+        "datexVersion": "DATEX संस्करण",
+        "jsVersion": "JS संस्करण",
+        "endpoint": "एंडपॉइंट",
+        "activeFeatures": "सक्रिय सुविधाएँ"
     }
-  }
+}

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -1,0 +1,86 @@
+{
+    "welcome": {
+  "subtitle": "DATEX रनटाइम के लिए डेवलपर टूलिंग",
+  "quickActions": "त्वरित क्रियाएं",
+  "networkDesc": "रीयल टाइम में DATEX नेटवर्क ब्लॉक की निगरानी करें",
+  "nodeDesc": "DATEX नोड ग्राफ़ देखें और संपादित करें",
+  "editorDesc": "वर्कबेंच में DATEX फ़ाइलें संपादित करें",
+  "replDesc": "इंटरैक्टिव DATEX रनटाइम वातावरण",
+  "soon": "जल्द ही",
+  "fileEditor": "फ़ाइल संपादक",
+  "repl": "REPL"
+},
+    "common": {
+      "loading": "लोड हो रहा है...",
+      "save": "सहेजें",
+      "cancel": "रद्द करें",
+      "delete": "हटाएं",
+      "close": "बंद करें",
+      "open": "खोलें",
+      "search": "खोजें",
+      "settings": "सेटिंग्स",
+      "language": "भाषा"
+    },
+    "nav": {
+      "block": "ब्लॉक",
+      "network": "नेटवर्क",
+      "nodeView": "नोड दृश्य",
+      "networkTree": "नेटवर्क ट्री",
+      "collection": "संग्रह",
+      "about": "बारे में"
+    },
+    "block": {
+      "openFile": "फ़ाइल खोलें",
+      "saveBin": ".bin सहेजें",
+      "dropHint": "एक .bin फ़ाइल यहाँ छोड़ें या \"फ़ाइल खोलें\" क्लिक करें",
+      "dropOverlay": ".bin फ़ाइल यहाँ छोड़ें",
+      "loadExample": "उदाहरण ब्लॉक लोड करें",
+      "fileEmpty": "फ़ाइल खाली है",
+      "invalidBlock": "अमान्य DXB ब्लॉक — मैजिक नंबर मेल नहीं खाता"
+    },
+    "disassembler": {
+      "disassembler": "डिसअसेंबलर",
+      "decompiler": "डीकंपाइलर",
+      "tree": "ट्री",
+      "flat": "सपाट",
+      "nested": "नेस्टेड",
+      "noInstructions": "दिखाने के लिए कोई निर्देश नहीं"
+    },
+    "network": {
+      "title": "नेटवर्क इंस्पेक्टर",
+      "blockViewer": "ब्लॉक व्यूअर",
+      "deleteBlocks": "ब्लॉक हटाएं?",
+      "deleteConfirm": "यह क्रिया पूर्ववत नहीं की जा सकती।",
+      "clearAll": "सभी प्रदर्शित ब्लॉक साफ़ करें"
+    },
+    "trace": {
+      "endpoint": "@एंडपॉइंट",
+      "timeout": "टाइमआउट (ms)",
+      "trace": "ट्रेस",
+      "tracing": "ट्रेस कर रहा है...",
+      "autoTrace": "ऑटो-ट्रेस",
+      "autoTracing": "ऑटो-ट्रेस कर रहा है...",
+      "endpointUnreachable": "एंडपॉइंट तक नहीं पहुँचा जा सकता",
+      "tracePlaceholder": "नेटवर्क पथ देखने के लिए एक ट्रेस भेजें"
+    },
+    "collection": {
+      "title": "संग्रह",
+      "id": "आईडी",
+      "name": "नाम",
+      "age": "आयु",
+      "admin": "एडमिन",
+      "registered": "पंजीकृत",
+      "yes": "हाँ",
+      "no": "नहीं",
+      "showing": "{total} में से {from}–{to} दिखा रहा है",
+      "previous": "पिछला",
+      "next": "अगला"
+    },
+    "about": {
+      "title": "बारे में",
+      "datexVersion": "DATEX संस्करण",
+      "jsVersion": "JS संस्करण",
+      "endpoint": "एंडपॉइंट",
+      "activeFeatures": "सक्रिय सुविधाएँ"
+    }
+  }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,10 @@ import './assets/main.css';
 import { createApp } from 'vue';
 import App from './App.vue';
 import router from './router';
+import { i18n } from './i18n'
+
 
 const app = createApp(App);
 app.use(router);
+app.use(i18n)
 app.mount('#app');

--- a/src/views/WelcomeView.vue
+++ b/src/views/WelcomeView.vue
@@ -1,39 +1,42 @@
 <script setup lang="ts">
 import { useRouter } from 'vue-router'
 import IconLogo from '@/components/icons/IconLogo.vue'
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 
+const { t } = useI18n()
 const router = useRouter()
 
-const quickActions = [
+const quickActions = computed(() => [
   {
-    label: 'Network Inspector',
-    description: 'Monitor and inspect DATEX network blocks in real time',
+    label: t('nav.network'),
+    description: t('welcome.networkDesc'),
     icon: 'network',
     route: '/network',
     available: true,
   },
   {
-    label: 'Node View',
-    description: 'Visualize and edit the DATEX node graph',
+    label: t('nav.nodeView'),
+    description: t('welcome.nodeDesc'),
     icon: 'node',
     route: '/node-view',
     available: true,
   },
   {
-    label: 'File Editor',
-    description: 'Edit DATEX files directly in the workbench',
+    label: t('welcome.fileEditor'),
+    description: t('welcome.editorDesc'),
     icon: 'editor',
     route: '/editor',
     available: true,
   },
   {
-    label: 'REPL',
-    description: 'Interactive DATEX runtime environment',
+    label: t('welcome.repl'),
+    description: t('welcome.replDesc'),
     icon: 'repl',
     route: null,
     available: false,
   },
-]
+])
 
 function navigate(route: string | null) {
   if (route) router.push(route)
@@ -51,7 +54,7 @@ function navigate(route: string | null) {
         </h1>
       </div>
       <p class="text-sm text-muted-foreground">
-        Developer tooling for the DATEX runtime
+        {{ t('welcome.subtitle') }}
       </p>
     </div>
 


### PR DESCRIPTION
## feat: i18n with vue-i18n

Adds internationalization support using `vue-i18n@11`. English is the fallback locale.

### Languages
- English (`en`): fallback
- German (`de`)
- Hindi (`hi`)

### Features
- Language switcher in the header (next to theme toggle)
- Selected locale persists to localStorage (`datex-workbench-locale`)
- Browser language auto-detected on first visit
- `<html lang>` updated on locale change

### Files added
- `src/i18n.ts` — setup, `SUPPORTED_LOCALES`, `setLocale()`
- `src/locales/en.json`, `de.json`, `hi.json`: translation strings organized by section (`common`, `nav`, `block`, `disassembler`, `network`, `trace`, `collection`, `about`, `welcome`)
- `src/components/LanguageSwitcher.vue`: dropdown component

### Files modified
- `src/main.ts`: register i18n plugin
- `src/components/HeaderProvider.vue`: add `LanguageSwitcher` next to `ThemeSwitch`
- `src/views/WelcomeView.vue`: wired up to use `t()` calls (proof of concept)

### Notes
Only `WelcomeView` uses `t()` so far. Translation keys are pre-defined in JSON for the rest of the app, those views can be wired up incrementally without changing the locale setup.