### PR TITLE
feat: preferences page with persistent storage and reset functionality

### DIFF
--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -145,7 +145,7 @@ const navigate = (path: string) => {
                     <div
                         class="card invisible absolute left-14 z-50 m-0 ml-2 whitespace-nowrap px-3 py-1.5 text-xs font-mono shadow-xl group-hover:visible"
                     >
-                        Preferences
+                        {{t('nav.preferences')}}
 
                         <div
                             class="bg-card border-l border-b border-neutral-200 dark:border-neutral-700 absolute -left-1 top-1/2 h-2 w-2 -translate-y-1/2 rotate-45"

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -145,7 +145,7 @@ const navigate = (path: string) => {
                     <div
                         class="card invisible absolute left-14 z-50 m-0 ml-2 whitespace-nowrap px-3 py-1.5 text-xs font-mono shadow-xl group-hover:visible"
                     >
-                        {{t('nav.preferences')}}
+                        {{ t('nav.preferences') }}
 
                         <div
                             class="bg-card border-l border-b border-neutral-200 dark:border-neutral-700 absolute -left-1 top-1/2 h-2 w-2 -translate-y-1/2 rotate-45"

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -1,9 +1,8 @@
 <script lang="ts" setup>
 import { ref, computed } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
-import ThemeSwitch from '@/components/ThemeSwitch.vue';
 import IconLogo from '@/components/icons/IconLogo.vue';
-import { Network, SendToBack, Terminal, Box, GitGraph, Cpu, Info } from 'lucide-vue-next';
+import { Network, SendToBack, Terminal, Box, GitGraph, Cpu, Info, Settings } from 'lucide-vue-next';
 import draggable from 'vuedraggable';
 import { useI18n } from 'vue-i18n';
 
@@ -49,7 +48,7 @@ const navigate = (path: string) => {
         <!-- For Collapse -->
         <!-- :class="[isCollapsed ? 'pointer-events-none opacity-0' : 'opacity-100']" -->
         <div
-            class="flex flex-col items-center wco-container transition-opacity duration-200 h-full"
+            class="flex flex-col items-center wco-container transition-opacity duration-200 h-full min-h-0 overflow-y-auto"
         >
             <div
                 class="group relative flex w-full cursor-pointer items-center justify-center py-2"
@@ -121,8 +120,38 @@ const navigate = (path: string) => {
                     </div>
                 </template>
             </draggable>
-            <div class="mt-auto pb-4">
-                <ThemeSwitch />
+
+            <div class="mt-auto pb-4 w-full">
+                <div
+                    class="group relative flex w-full cursor-pointer items-center justify-center py-2"
+                    @click="navigate('/preferences')"
+                >
+                    <div
+                        class="absolute left-0 h-10 w-0.5 rounded-full bg-sidebar-border transition-all"
+                        :class="activePath === '/preferences' ? 'opacity-100' : 'opacity-0'"
+                    ></div>
+
+                    <div
+                        class="rounded-md p-2 transition-colors"
+                        :class="
+                            activePath === '/preferences'
+                                ? 'text-sidebar-foreground'
+                                : 'text-dim hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'
+                        "
+                    >
+                        <Settings :size="28" :stroke-width="1.5" />
+                    </div>
+
+                    <div
+                        class="card invisible absolute left-14 z-50 m-0 ml-2 whitespace-nowrap px-3 py-1.5 text-xs font-mono shadow-xl group-hover:visible"
+                    >
+                        Preferences
+
+                        <div
+                            class="bg-card border-l border-b border-neutral-200 dark:border-neutral-700 absolute -left-1 top-1/2 h-2 w-2 -translate-y-1/2 rotate-45"
+                        ></div>
+                    </div>
+                </div>
             </div>
         </div>
     </aside>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -46,7 +46,8 @@
         "about": "Über",
         "repl": "REPL",
         "comhub": "ComHub",
-        "networkVisualizer": "Netzwerk-Visualisierer"
+        "networkVisualizer": "Netzwerk-Visualisierer",
+        "preferences": "Einstellungen"
     },
     "block": {
         "openFile": "Datei öffnen",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -46,7 +46,8 @@
         "about": "About",
         "repl": "REPL",
         "comhub": "ComHub",
-        "networkVisualizer": "Network Visualizer"
+        "networkVisualizer": "Network Visualizer",
+        "preferences": "Preferences"
     },
     "block": {
         "openFile": "Open File",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -46,7 +46,8 @@
         "about": "बारे में",
         "repl": "REPL",
         "comhub": "ComHub",
-        "networkVisualizer": "नेटवर्क विज़ुअलाइज़र"
+        "networkVisualizer": "नेटवर्क विज़ुअलाइज़र",
+        "preferences": "प्राथमिकताएँ"
     },
     "block": {
         "openFile": "फ़ाइल खोलें",

--- a/src/preferences/index.ts
+++ b/src/preferences/index.ts
@@ -1,2 +1,2 @@
-export { usePreferences } from './store'
-export { DEFAULT_PREFERENCES, type Preferences } from './schema'
+export { usePreferences } from './store';
+export { DEFAULT_PREFERENCES, type Preferences } from './schema';

--- a/src/preferences/index.ts
+++ b/src/preferences/index.ts
@@ -1,0 +1,2 @@
+export { usePreferences } from './store'
+export { DEFAULT_PREFERENCES, type Preferences } from './schema'

--- a/src/preferences/schema.ts
+++ b/src/preferences/schema.ts
@@ -1,0 +1,31 @@
+export interface Preferences {
+  appearance: {
+    theme: 'system' | 'light' | 'dark'
+    highContrast: boolean
+    reduceMotion: boolean
+  }
+  language: {
+    locale: 'en' | 'de' | 'hi'
+  }
+  editor: {
+    fontSize: number
+    showLineNumbers: boolean
+  }
+}
+
+export const DEFAULT_PREFERENCES: Preferences = {
+  appearance: {
+    theme: 'system',
+    highContrast: false,
+    reduceMotion: false,
+  },
+  language: {
+    locale: 'en',
+  },
+  editor: {
+    fontSize: 14,
+    showLineNumbers: true,
+  },
+}
+
+export const STORAGE_KEY = 'datex-workbench-preferences'

--- a/src/preferences/schema.ts
+++ b/src/preferences/schema.ts
@@ -1,31 +1,31 @@
 export interface Preferences {
-  appearance: {
-    theme: 'system' | 'light' | 'dark'
-    highContrast: boolean
-    reduceMotion: boolean
-  }
-  language: {
-    locale: 'en' | 'de' | 'hi'
-  }
-  editor: {
-    fontSize: number
-    showLineNumbers: boolean
-  }
+    appearance: {
+        theme: 'system' | 'light' | 'dark';
+        highContrast: boolean;
+        reduceMotion: boolean;
+    };
+    language: {
+        locale: 'en' | 'de' | 'hi';
+    };
+    editor: {
+        fontSize: number;
+        showLineNumbers: boolean;
+    };
 }
 
 export const DEFAULT_PREFERENCES: Preferences = {
-  appearance: {
-    theme: 'system',
-    highContrast: false,
-    reduceMotion: false,
-  },
-  language: {
-    locale: 'en',
-  },
-  editor: {
-    fontSize: 14,
-    showLineNumbers: true,
-  },
-}
+    appearance: {
+        theme: 'system',
+        highContrast: false,
+        reduceMotion: false,
+    },
+    language: {
+        locale: 'en',
+    },
+    editor: {
+        fontSize: 14,
+        showLineNumbers: true,
+    },
+};
 
-export const STORAGE_KEY = 'datex-workbench-preferences'
+export const STORAGE_KEY = 'datex-workbench-preferences';

--- a/src/preferences/store.ts
+++ b/src/preferences/store.ts
@@ -1,8 +1,8 @@
-import { reactive, watch } from 'vue'
-import { DEFAULT_PREFERENCES, STORAGE_KEY, type Preferences } from './schema'
+import { reactive, watch } from 'vue';
+import { DEFAULT_PREFERENCES, STORAGE_KEY, type Preferences } from './schema';
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 /**
@@ -10,59 +10,60 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  * later, existing users with stored partial preferences get the new defaults
  * filled in automatically.
  */
-function mergeDeep<T extends object>(target: T, source: Partial<T>): T {  for (const key in source) {
-    const sourceVal = source[key]
-    const targetVal = target[key]
-    if (isPlainObject(sourceVal) && isPlainObject(targetVal)) {
-      target[key] = mergeDeep(
-        targetVal as object,
-        sourceVal as object,
-      ) as T[Extract<keyof T, string>]
-    } else if (sourceVal !== undefined) {
-      target[key] = sourceVal as T[Extract<keyof T, string>]
+function mergeDeep<T extends object>(target: T, source: Partial<T>): T {
+    for (const key in source) {
+        const sourceVal = source[key];
+        const targetVal = target[key];
+        if (isPlainObject(sourceVal) && isPlainObject(targetVal)) {
+            target[key] = mergeDeep(targetVal as object, sourceVal as object) as T[Extract<
+                keyof T,
+                string
+            >];
+        } else if (sourceVal !== undefined) {
+            target[key] = sourceVal as T[Extract<keyof T, string>];
+        }
     }
-  }
-  return target
+    return target;
 }
 
 function loadPreferences(): Preferences {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return structuredClone(DEFAULT_PREFERENCES)
-    const parsed = JSON.parse(raw) as Partial<Preferences>
-    return mergeDeep(structuredClone(DEFAULT_PREFERENCES), parsed)
-  } catch {
-    return structuredClone(DEFAULT_PREFERENCES)
-  }
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return structuredClone(DEFAULT_PREFERENCES);
+        const parsed = JSON.parse(raw) as Partial<Preferences>;
+        return mergeDeep(structuredClone(DEFAULT_PREFERENCES), parsed);
+    } catch {
+        return structuredClone(DEFAULT_PREFERENCES);
+    }
 }
 
-const preferences = reactive<Preferences>(loadPreferences())
+const preferences = reactive<Preferences>(loadPreferences());
 
 // Auto-persist on any change
 watch(
-  preferences,
-  (val) => {
-    try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(val))
-    } catch (err) {
-      console.error('[Preferences] Failed to save:', err)
-    }
-  },
-  { deep: true },
-)
+    preferences,
+    (val) => {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(val));
+        } catch (err) {
+            console.error('[Preferences] Failed to save:', err);
+        }
+    },
+    { deep: true },
+);
 
 function resetSection<K extends keyof Preferences>(section: K) {
-  preferences[section] = structuredClone(DEFAULT_PREFERENCES[section])
+    preferences[section] = structuredClone(DEFAULT_PREFERENCES[section]);
 }
 
 function resetAll() {
-  Object.assign(preferences, structuredClone(DEFAULT_PREFERENCES))
+    Object.assign(preferences, structuredClone(DEFAULT_PREFERENCES));
 }
 
 export function usePreferences() {
-  return {
-    preferences,
-    resetSection,
-    resetAll,
-  }
+    return {
+        preferences,
+        resetSection,
+        resetAll,
+    };
 }

--- a/src/preferences/store.ts
+++ b/src/preferences/store.ts
@@ -1,0 +1,68 @@
+import { reactive, watch } from 'vue'
+import { DEFAULT_PREFERENCES, STORAGE_KEY, type Preferences } from './schema'
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Deep-merges `source` into `target`. Used so that when we add new preferences
+ * later, existing users with stored partial preferences get the new defaults
+ * filled in automatically.
+ */
+function mergeDeep<T extends object>(target: T, source: Partial<T>): T {  for (const key in source) {
+    const sourceVal = source[key]
+    const targetVal = target[key]
+    if (isPlainObject(sourceVal) && isPlainObject(targetVal)) {
+      target[key] = mergeDeep(
+        targetVal as object,
+        sourceVal as object,
+      ) as T[Extract<keyof T, string>]
+    } else if (sourceVal !== undefined) {
+      target[key] = sourceVal as T[Extract<keyof T, string>]
+    }
+  }
+  return target
+}
+
+function loadPreferences(): Preferences {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return structuredClone(DEFAULT_PREFERENCES)
+    const parsed = JSON.parse(raw) as Partial<Preferences>
+    return mergeDeep(structuredClone(DEFAULT_PREFERENCES), parsed)
+  } catch {
+    return structuredClone(DEFAULT_PREFERENCES)
+  }
+}
+
+const preferences = reactive<Preferences>(loadPreferences())
+
+// Auto-persist on any change
+watch(
+  preferences,
+  (val) => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(val))
+    } catch (err) {
+      console.error('[Preferences] Failed to save:', err)
+    }
+  },
+  { deep: true },
+)
+
+function resetSection<K extends keyof Preferences>(section: K) {
+  preferences[section] = structuredClone(DEFAULT_PREFERENCES[section])
+}
+
+function resetAll() {
+  Object.assign(preferences, structuredClone(DEFAULT_PREFERENCES))
+}
+
+export function usePreferences() {
+  return {
+    preferences,
+    resetSection,
+    resetAll,
+  }
+}

--- a/src/preferences/store.ts
+++ b/src/preferences/store.ts
@@ -1,4 +1,6 @@
 import { reactive, watch } from 'vue';
+import { useColorMode } from '@vueuse/core';
+import { setLocale } from '@/i18n';
 import { DEFAULT_PREFERENCES, STORAGE_KEY, type Preferences } from './schema';
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -50,6 +52,29 @@ watch(
         }
     },
     { deep: true },
+);
+
+// --- Sync watchers ---
+
+// Theme: preferences.appearance.theme → vueuse useColorMode
+const mode = useColorMode();
+function applyTheme(theme: Preferences['appearance']['theme']) {
+    mode.value = theme === 'system' ? 'auto' : theme;
+}
+applyTheme(preferences.appearance.theme); // initial
+watch(
+    () => preferences.appearance.theme,
+    (next) => applyTheme(next),
+);
+
+// Locale: preferences.language.locale → i18n + document.documentElement.lang
+function applyLocale(locale: Preferences['language']['locale']) {
+    setLocale(locale); // already updates i18n + localStorage + html lang
+}
+applyLocale(preferences.language.locale); // initial
+watch(
+    () => preferences.language.locale,
+    (next) => applyLocale(next),
 );
 
 function resetSection<K extends keyof Preferences>(section: K) {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -73,9 +73,9 @@ const router = createRouter({
             component: NetworkTraceView,
         },
         {
-          path: '/preferences',
-          name: 'preferences',
-          component: () => import('@/views/PreferencesView.vue'),
+            path: '/preferences',
+            name: 'preferences',
+            component: () => import('@/views/PreferencesView.vue'),
         },
     ],
 });

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -72,6 +72,11 @@ const router = createRouter({
             name: 'network-visualizer',
             component: NetworkTraceView,
         },
+        {
+          path: '/preferences',
+          name: 'preferences',
+          component: () => import('@/views/PreferencesView.vue'),
+        },
     ],
 });
 

--- a/src/views/PreferencesView.vue
+++ b/src/views/PreferencesView.vue
@@ -14,8 +14,8 @@ function confirmResetAll() {
 </script>
 
 <template>
-    <div class="flex h-full w-full justify-center overflow-y-auto p-6">
-        <div class="w-full max-w-2xl space-y-6">
+    <div class="flex h-full w-full justify-center items-center overflow-y-auto p-6">
+        <div class="w-full max-w-2xl space-y-6 my-auto">
             <!-- Header -->
             <div class="flex items-center justify-between">
                 <h1 class="text-2xl font-semibold text-foreground">Preferences</h1>

--- a/src/views/PreferencesView.vue
+++ b/src/views/PreferencesView.vue
@@ -1,0 +1,188 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { usePreferences } from '@/preferences'
+import { RotateCcw, AlertTriangle } from 'lucide-vue-next'
+
+const { preferences, resetSection, resetAll } = usePreferences()
+
+const showResetAllConfirm = ref(false)
+
+function confirmResetAll() {
+  resetAll()
+  showResetAllConfirm.value = false
+}
+</script>
+
+<template>
+  <div class="flex h-full w-full justify-center overflow-y-auto p-6">
+    <div class="w-full max-w-2xl space-y-6">
+      <!-- Header -->
+      <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-semibold text-foreground">Preferences</h1>
+        <button
+          class="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition"
+          @click="showResetAllConfirm = true"
+        >
+          <RotateCcw class="size-3.5" />
+          Reset all
+        </button>
+      </div>
+
+      <!-- Appearance -->
+      <section class="rounded-xl border border-border bg-card p-6">
+        <header class="mb-4 flex items-center justify-between">
+          <h2 class="text-lg font-medium text-foreground">Appearance</h2>
+          <button
+            class="text-xs text-muted-foreground hover:text-foreground transition"
+            @click="resetSection('appearance')"
+          >
+            Reset
+          </button>
+        </header>
+
+        <div class="space-y-4">
+          <div class="flex items-center justify-between">
+            <div>
+              <div class="text-sm text-foreground">Theme</div>
+              <div class="text-xs text-muted-foreground">Choose the color theme</div>
+            </div>
+            <select
+              v-model="preferences.appearance.theme"
+              class="bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground"
+            >
+              <option value="system">System</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+
+          <div class="flex items-center justify-between">
+            <div>
+              <div class="text-sm text-foreground">High contrast</div>
+              <div class="text-xs text-muted-foreground">Increase contrast for better readability</div>
+            </div>
+            <input
+              v-model="preferences.appearance.highContrast"
+              type="checkbox"
+              class="size-4 accent-primary cursor-pointer"
+            />
+          </div>
+
+          <div class="flex items-center justify-between">
+            <div>
+              <div class="text-sm text-foreground">Reduce motion</div>
+              <div class="text-xs text-muted-foreground">Minimize animations and transitions</div>
+            </div>
+            <input
+              v-model="preferences.appearance.reduceMotion"
+              type="checkbox"
+              class="size-4 accent-primary cursor-pointer"
+            />
+          </div>
+        </div>
+      </section>
+
+      <!-- Language -->
+      <section class="rounded-xl border border-border bg-card p-6">
+        <header class="mb-4 flex items-center justify-between">
+          <h2 class="text-lg font-medium text-foreground">Language</h2>
+          <button
+            class="text-xs text-muted-foreground hover:text-foreground transition"
+            @click="resetSection('language')"
+          >
+            Reset
+          </button>
+        </header>
+
+        <div class="flex items-center justify-between">
+          <div>
+            <div class="text-sm text-foreground">Locale</div>
+            <div class="text-xs text-muted-foreground">Interface language</div>
+          </div>
+          <select
+            v-model="preferences.language.locale"
+            class="bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground"
+          >
+            <option value="en">English</option>
+            <option value="de">Deutsch</option>
+            <option value="hi">हिन्दी</option>
+          </select>
+        </div>
+      </section>
+
+      <!-- Editor -->
+      <section class="rounded-xl border border-border bg-card p-6">
+        <header class="mb-4 flex items-center justify-between">
+          <h2 class="text-lg font-medium text-foreground">Editor</h2>
+          <button
+            class="text-xs text-muted-foreground hover:text-foreground transition"
+            @click="resetSection('editor')"
+          >
+            Reset
+          </button>
+        </header>
+
+        <div class="space-y-4">
+          <div class="flex items-center justify-between">
+            <div>
+              <div class="text-sm text-foreground">Font size</div>
+              <div class="text-xs text-muted-foreground">Editor text size in pixels</div>
+            </div>
+            <input
+              v-model.number="preferences.editor.fontSize"
+              type="number"
+              min="10"
+              max="24"
+              class="bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground w-20"
+            />
+          </div>
+
+          <div class="flex items-center justify-between">
+            <div>
+              <div class="text-sm text-foreground">Show line numbers</div>
+              <div class="text-xs text-muted-foreground">Display line numbers in the editor</div>
+            </div>
+            <input
+              v-model="preferences.editor.showLineNumbers"
+              type="checkbox"
+              class="size-4 accent-primary cursor-pointer"
+            />
+          </div>
+        </div>
+      </section>
+
+      <!-- Reset all confirmation -->
+      <div
+        v-if="showResetAllConfirm"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-background/80"
+        @click.self="showResetAllConfirm = false"
+      >
+        <div class="rounded-xl border border-border bg-card p-6 max-w-sm shadow-lg">
+          <div class="flex items-start gap-3">
+            <AlertTriangle class="size-5 text-yellow-500 flex-shrink-0 mt-0.5" />
+            <div>
+              <h3 class="text-sm font-medium text-foreground">Reset all preferences?</h3>
+              <p class="mt-1 text-xs text-muted-foreground">
+                This will restore all settings to their default values. This action cannot be undone.
+              </p>
+            </div>
+          </div>
+          <div class="mt-5 flex justify-end gap-2">
+            <button
+              class="rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-muted transition"
+              @click="showResetAllConfirm = false"
+            >
+              Cancel
+            </button>
+            <button
+              class="rounded-md bg-red-600 hover:bg-red-700 px-3 py-1.5 text-xs text-white transition"
+              @click="confirmResetAll"
+            >
+              Reset all
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/views/PreferencesView.vue
+++ b/src/views/PreferencesView.vue
@@ -1,188 +1,199 @@
 <script setup lang="ts">
-import { ref } from 'vue'
-import { usePreferences } from '@/preferences'
-import { RotateCcw, AlertTriangle } from 'lucide-vue-next'
+import { ref } from 'vue';
+import { usePreferences } from '@/preferences';
+import { RotateCcw, AlertTriangle } from 'lucide-vue-next';
 
-const { preferences, resetSection, resetAll } = usePreferences()
+const { preferences, resetSection, resetAll } = usePreferences();
 
-const showResetAllConfirm = ref(false)
+const showResetAllConfirm = ref(false);
 
 function confirmResetAll() {
-  resetAll()
-  showResetAllConfirm.value = false
+    resetAll();
+    showResetAllConfirm.value = false;
 }
 </script>
 
 <template>
-  <div class="flex h-full w-full justify-center overflow-y-auto p-6">
-    <div class="w-full max-w-2xl space-y-6">
-      <!-- Header -->
-      <div class="flex items-center justify-between">
-        <h1 class="text-2xl font-semibold text-foreground">Preferences</h1>
-        <button
-          class="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition"
-          @click="showResetAllConfirm = true"
-        >
-          <RotateCcw class="size-3.5" />
-          Reset all
-        </button>
-      </div>
-
-      <!-- Appearance -->
-      <section class="rounded-xl border border-border bg-card p-6">
-        <header class="mb-4 flex items-center justify-between">
-          <h2 class="text-lg font-medium text-foreground">Appearance</h2>
-          <button
-            class="text-xs text-muted-foreground hover:text-foreground transition"
-            @click="resetSection('appearance')"
-          >
-            Reset
-          </button>
-        </header>
-
-        <div class="space-y-4">
-          <div class="flex items-center justify-between">
-            <div>
-              <div class="text-sm text-foreground">Theme</div>
-              <div class="text-xs text-muted-foreground">Choose the color theme</div>
+    <div class="flex h-full w-full justify-center overflow-y-auto p-6">
+        <div class="w-full max-w-2xl space-y-6">
+            <!-- Header -->
+            <div class="flex items-center justify-between">
+                <h1 class="text-2xl font-semibold text-foreground">Preferences</h1>
+                <button
+                    class="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition"
+                    @click="showResetAllConfirm = true"
+                >
+                    <RotateCcw class="size-3.5" />
+                    Reset all
+                </button>
             </div>
-            <select
-              v-model="preferences.appearance.theme"
-              class="bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground"
+
+            <!-- Appearance -->
+            <section class="rounded-xl border border-border bg-card p-6">
+                <header class="mb-4 flex items-center justify-between">
+                    <h2 class="text-lg font-medium text-foreground">Appearance</h2>
+                    <button
+                        class="text-xs text-muted-foreground hover:text-foreground transition"
+                        @click="resetSection('appearance')"
+                    >
+                        Reset
+                    </button>
+                </header>
+
+                <div class="space-y-4">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <div class="text-sm text-foreground">Theme</div>
+                            <div class="text-xs text-muted-foreground">Choose the color theme</div>
+                        </div>
+                        <select
+                            v-model="preferences.appearance.theme"
+                            class="bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground"
+                        >
+                            <option value="system">System</option>
+                            <option value="light">Light</option>
+                            <option value="dark">Dark</option>
+                        </select>
+                    </div>
+
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <div class="text-sm text-foreground">High contrast</div>
+                            <div class="text-xs text-muted-foreground">
+                                Increase contrast for better readability
+                            </div>
+                        </div>
+                        <input
+                            v-model="preferences.appearance.highContrast"
+                            type="checkbox"
+                            class="size-4 accent-primary cursor-pointer"
+                        />
+                    </div>
+
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <div class="text-sm text-foreground">Reduce motion</div>
+                            <div class="text-xs text-muted-foreground">
+                                Minimize animations and transitions
+                            </div>
+                        </div>
+                        <input
+                            v-model="preferences.appearance.reduceMotion"
+                            type="checkbox"
+                            class="size-4 accent-primary cursor-pointer"
+                        />
+                    </div>
+                </div>
+            </section>
+
+            <!-- Language -->
+            <section class="rounded-xl border border-border bg-card p-6">
+                <header class="mb-4 flex items-center justify-between">
+                    <h2 class="text-lg font-medium text-foreground">Language</h2>
+                    <button
+                        class="text-xs text-muted-foreground hover:text-foreground transition"
+                        @click="resetSection('language')"
+                    >
+                        Reset
+                    </button>
+                </header>
+
+                <div class="flex items-center justify-between">
+                    <div>
+                        <div class="text-sm text-foreground">Locale</div>
+                        <div class="text-xs text-muted-foreground">Interface language</div>
+                    </div>
+                    <select
+                        v-model="preferences.language.locale"
+                        class="bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground"
+                    >
+                        <option value="en">English</option>
+                        <option value="de">Deutsch</option>
+                        <option value="hi">हिन्दी</option>
+                    </select>
+                </div>
+            </section>
+
+            <!-- Editor -->
+            <section class="rounded-xl border border-border bg-card p-6">
+                <header class="mb-4 flex items-center justify-between">
+                    <h2 class="text-lg font-medium text-foreground">Editor</h2>
+                    <button
+                        class="text-xs text-muted-foreground hover:text-foreground transition"
+                        @click="resetSection('editor')"
+                    >
+                        Reset
+                    </button>
+                </header>
+
+                <div class="space-y-4">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <div class="text-sm text-foreground">Font size</div>
+                            <div class="text-xs text-muted-foreground">
+                                Editor text size in pixels
+                            </div>
+                        </div>
+                        <input
+                            v-model.number="preferences.editor.fontSize"
+                            type="number"
+                            min="10"
+                            max="24"
+                            class="bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground w-20"
+                        />
+                    </div>
+
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <div class="text-sm text-foreground">Show line numbers</div>
+                            <div class="text-xs text-muted-foreground">
+                                Display line numbers in the editor
+                            </div>
+                        </div>
+                        <input
+                            v-model="preferences.editor.showLineNumbers"
+                            type="checkbox"
+                            class="size-4 accent-primary cursor-pointer"
+                        />
+                    </div>
+                </div>
+            </section>
+
+            <!-- Reset all confirmation -->
+            <div
+                v-if="showResetAllConfirm"
+                class="fixed inset-0 z-50 flex items-center justify-center bg-background/80"
+                @click.self="showResetAllConfirm = false"
             >
-              <option value="system">System</option>
-              <option value="light">Light</option>
-              <option value="dark">Dark</option>
-            </select>
-          </div>
-
-          <div class="flex items-center justify-between">
-            <div>
-              <div class="text-sm text-foreground">High contrast</div>
-              <div class="text-xs text-muted-foreground">Increase contrast for better readability</div>
+                <div class="rounded-xl border border-border bg-card p-6 max-w-sm shadow-lg">
+                    <div class="flex items-start gap-3">
+                        <AlertTriangle class="size-5 text-yellow-500 flex-shrink-0 mt-0.5" />
+                        <div>
+                            <h3 class="text-sm font-medium text-foreground">
+                                Reset all preferences?
+                            </h3>
+                            <p class="mt-1 text-xs text-muted-foreground">
+                                This will restore all settings to their default values. This action
+                                cannot be undone.
+                            </p>
+                        </div>
+                    </div>
+                    <div class="mt-5 flex justify-end gap-2">
+                        <button
+                            class="rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-muted transition"
+                            @click="showResetAllConfirm = false"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            class="rounded-md bg-red-600 hover:bg-red-700 px-3 py-1.5 text-xs text-white transition"
+                            @click="confirmResetAll"
+                        >
+                            Reset all
+                        </button>
+                    </div>
+                </div>
             </div>
-            <input
-              v-model="preferences.appearance.highContrast"
-              type="checkbox"
-              class="size-4 accent-primary cursor-pointer"
-            />
-          </div>
-
-          <div class="flex items-center justify-between">
-            <div>
-              <div class="text-sm text-foreground">Reduce motion</div>
-              <div class="text-xs text-muted-foreground">Minimize animations and transitions</div>
-            </div>
-            <input
-              v-model="preferences.appearance.reduceMotion"
-              type="checkbox"
-              class="size-4 accent-primary cursor-pointer"
-            />
-          </div>
         </div>
-      </section>
-
-      <!-- Language -->
-      <section class="rounded-xl border border-border bg-card p-6">
-        <header class="mb-4 flex items-center justify-between">
-          <h2 class="text-lg font-medium text-foreground">Language</h2>
-          <button
-            class="text-xs text-muted-foreground hover:text-foreground transition"
-            @click="resetSection('language')"
-          >
-            Reset
-          </button>
-        </header>
-
-        <div class="flex items-center justify-between">
-          <div>
-            <div class="text-sm text-foreground">Locale</div>
-            <div class="text-xs text-muted-foreground">Interface language</div>
-          </div>
-          <select
-            v-model="preferences.language.locale"
-            class="bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground"
-          >
-            <option value="en">English</option>
-            <option value="de">Deutsch</option>
-            <option value="hi">हिन्दी</option>
-          </select>
-        </div>
-      </section>
-
-      <!-- Editor -->
-      <section class="rounded-xl border border-border bg-card p-6">
-        <header class="mb-4 flex items-center justify-between">
-          <h2 class="text-lg font-medium text-foreground">Editor</h2>
-          <button
-            class="text-xs text-muted-foreground hover:text-foreground transition"
-            @click="resetSection('editor')"
-          >
-            Reset
-          </button>
-        </header>
-
-        <div class="space-y-4">
-          <div class="flex items-center justify-between">
-            <div>
-              <div class="text-sm text-foreground">Font size</div>
-              <div class="text-xs text-muted-foreground">Editor text size in pixels</div>
-            </div>
-            <input
-              v-model.number="preferences.editor.fontSize"
-              type="number"
-              min="10"
-              max="24"
-              class="bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground w-20"
-            />
-          </div>
-
-          <div class="flex items-center justify-between">
-            <div>
-              <div class="text-sm text-foreground">Show line numbers</div>
-              <div class="text-xs text-muted-foreground">Display line numbers in the editor</div>
-            </div>
-            <input
-              v-model="preferences.editor.showLineNumbers"
-              type="checkbox"
-              class="size-4 accent-primary cursor-pointer"
-            />
-          </div>
-        </div>
-      </section>
-
-      <!-- Reset all confirmation -->
-      <div
-        v-if="showResetAllConfirm"
-        class="fixed inset-0 z-50 flex items-center justify-center bg-background/80"
-        @click.self="showResetAllConfirm = false"
-      >
-        <div class="rounded-xl border border-border bg-card p-6 max-w-sm shadow-lg">
-          <div class="flex items-start gap-3">
-            <AlertTriangle class="size-5 text-yellow-500 flex-shrink-0 mt-0.5" />
-            <div>
-              <h3 class="text-sm font-medium text-foreground">Reset all preferences?</h3>
-              <p class="mt-1 text-xs text-muted-foreground">
-                This will restore all settings to their default values. This action cannot be undone.
-              </p>
-            </div>
-          </div>
-          <div class="mt-5 flex justify-end gap-2">
-            <button
-              class="rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-muted transition"
-              @click="showResetAllConfirm = false"
-            >
-              Cancel
-            </button>
-            <button
-              class="rounded-md bg-red-600 hover:bg-red-700 px-3 py-1.5 text-xs text-white transition"
-              @click="confirmResetAll"
-            >
-              Reset all
-            </button>
-          </div>
-        </div>
-      </div>
     </div>
-  </div>
 </template>


### PR DESCRIPTION
## feat: User Preferences Page

Adds a new `/preferences` route with a settings page backed by a type-safe, persistent preferences API.

### API Design

**`src/preferences/schema.ts`**: single source of truth for all preferences

**`src/preferences/store.ts`**: reactive composable

- Singleton reactive object-> all components share state, no prop drilling
- Auto-saves to localStorage on any change (deep watch)
- Deep-merge on load-> adding new preferences later won't lose existing user settings
- Per-section and global reset

### Adding a new preference (3 steps)
1. Add field to `Preferences` interface
2. Add default in `DEFAULT_PREFERENCES`
3. Add UI control: the store needs no changes

### Features
- **Appearance**: theme (system/light/dark), high contrast, reduce motion
- **Language**: en / de / hi
- **Editor**: font size, line numbers
- Per-section reset buttons
- Global "Reset all" with confirmation dialog

### Storage
- Single localStorage key: `***key***`
- Stored as JSON, deep-merged onto current defaults on load

### Files added
- `src/preferences/schema.ts`
- `src/preferences/store.ts`
- `src/preferences/index.ts`
- `src/views/PreferencesView.vue`

### Files modified
- `src/router/index.ts`: added `/preferences` route

### Notes
The preferences are not yet wired up to existing systems (theme switch, i18n locale). That integration can be done incrementally without touching the preferences API.