### PR TITLE
fix: enable independent scrolling in network inspector left panel

### DIFF
--- a/src/views/NetworkInspector/NetworkInspectorView.vue
+++ b/src/views/NetworkInspector/NetworkInspectorView.vue
@@ -189,7 +189,7 @@ const isBlockSecure = computed(() => {
     <div class="top-offset bg-background text-foreground flex h-full">
         <!-- Left panel: block list -->
         <div
-            class="flex flex-col p-4 pt-0"
+            class="flex flex-col p-4 h-full min-h-0 "
             :class="selectedBlock ? 'w-1/2 border-r border-border' : 'w-full'"
         >
             <div class="mb-4">
@@ -222,7 +222,7 @@ const isBlockSecure = computed(() => {
                 </div>
             </div>
 
-            <div ref="scrollContainerRef" class="flex-1 overflow-y-auto">
+            <div ref="scrollContainerRef" class="flex-1 min-h-0 overflow-y-auto">
                 <DataTable
                     :columns="dynamicColumns"
                     :data="tableRows"

--- a/src/views/NetworkInspector/NetworkInspectorView.vue
+++ b/src/views/NetworkInspector/NetworkInspectorView.vue
@@ -189,7 +189,7 @@ const isBlockSecure = computed(() => {
     <div class="top-offset bg-background text-foreground flex h-full">
         <!-- Left panel: block list -->
         <div
-            class="flex flex-col p-4 h-full min-h-0 "
+            class="flex flex-col p-4 h-full min-h-0"
             :class="selectedBlock ? 'w-1/2 border-r border-border' : 'w-full'"
         >
             <div class="mb-4">


### PR DESCRIPTION
## fix: enable independent scrolling in network inspector left panel

The left panel of the Network Inspector wasn't scrolling independently when the block viewer was open on the right, content overflowed past the viewport instead of producing its own scrollbar.

### Cause

In a flex column layout, the default `min-height: auto` makes flex children refuse to shrink below their content's intrinsic size. As a result, `overflow-y-auto` had nothing to scroll against, the container kept growing to fit its content.

### Fix

Added `min-h-0` to:
- the left panel wrapper (`flex flex-col p-4 h-full min-h-0`)
- the inner scroll container (`flex-1 min-h-0 overflow-y-auto`)

This lets the flex children shrink as expected, so `overflow-y-auto` now produces a scrollbar inside the panel rather than pushing content past the bounds.

### Files changed

- `src/views/NetworkInspector/NetworkInspectorView.vue`

### Verification

- Open Network Inspector with enough blocks to overflow
- Click a row to open the block viewer (split view)
- Left panel scrolls independently; right panel stays put