### PR TITLE
feat: allow PWA to open .dx and .dxb files in block viewer

### DIFF
--- a/src/lib/pwaLaunch.ts
+++ b/src/lib/pwaLaunch.ts
@@ -1,0 +1,12 @@
+// Holds a file launched by the OS until the BlockViewer route picks it up.
+let pendingFile: File | null = null;
+
+export function setPendingLaunchedFile(file: File) {
+    pendingFile = file;
+}
+
+export function consumePendingLaunchedFile(): File | null {
+    const f = pendingFile;
+    pendingFile = null;
+    return f;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,3 +9,19 @@ const app = createApp(App);
 app.use(router);
 app.use(i18n);
 app.mount('#app');
+
+// PWA file association: handle .dx / .dxb files opened from the OS
+if ('launchQueue' in window) {
+    // @ts-expect-error launchQueue is not yet in the DOM lib types
+    window.launchQueue.setConsumer(async (launchParams) => {
+        if (!launchParams.files?.length) return;
+
+        const fileHandle = launchParams.files[0];
+        const file = await fileHandle.getFile();
+
+        const { setPendingLaunchedFile } = await import('@/lib/pwaLaunch');
+        setPendingLaunchedFile(file);
+
+        router.push('/block');
+    });
+}

--- a/src/views/BlockViewer/DatexBlockProtocolViewWrapper.vue
+++ b/src/views/BlockViewer/DatexBlockProtocolViewWrapper.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, onMounted } from 'vue';
+import { consumePendingLaunchedFile } from '@/lib/pwaLaunch';
 import DatexBlockProtocolView from './DatexBlockProtocolView.vue';
 import { Upload, Download, FileWarning } from 'lucide-vue-next';
 import { parseStructure } from '@unyt/speck';
@@ -28,6 +29,11 @@ async function loadFile(file: File) {
         blockData.value = null;
     }
 }
+
+onMounted(() => {
+    const launched = consumePendingLaunchedFile();
+    if (launched) loadFile(launched);
+});
 
 function onDrop(event: DragEvent) {
     isDragging.value = false;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,40 +1,51 @@
-import tailwindcss from '@tailwindcss/vite'
-import vue from '@vitejs/plugin-vue'
-import { fileURLToPath, URL } from 'node:url'
-import { defineConfig } from 'vite'
-import { VitePWA } from 'vite-plugin-pwa'
+import tailwindcss from '@tailwindcss/vite';
+import vue from '@vitejs/plugin-vue';
+import { fileURLToPath, URL } from 'node:url';
+import { defineConfig } from 'vite';
+import { VitePWA } from 'vite-plugin-pwa';
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [vue(), tailwindcss(), VitePWA({
-    registerType: 'autoUpdate',
-    devOptions: {
-      enabled: true,
+    plugins: [
+        vue(),
+        tailwindcss(),
+        VitePWA({
+            registerType: 'autoUpdate',
+            devOptions: {
+                enabled: true,
+            },
+            manifest: {
+                name: 'DATEX Workbench',
+                short_name: 'Workbench',
+                description: 'Developer tooling UI for the DATEX runtime',
+                start_url: '/',
+                scope: '/',
+                display: 'standalone',
+                display_override: ['window-controls-overlay'],
+                theme_color: 'oklch(0.145 0 0)',
+                background_color: 'oklch(0.145 0 0))',
+                icons: [
+                    { src: '/icon.png', sizes: '192x192', type: 'image/png' },
+                    { src: '/icon.png', sizes: '512x512', type: 'image/png' },
+                ],
+                file_handlers: [
+                    {
+                        action: '/block',
+                        accept: {
+                            'application/octet-stream': ['.dx', '.dxb'],
+                        },
+                    },
+                ],
+            },
+            workbox: {
+                globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+            },
+        }),
+    ],
+    cacheDir: 'node_modules/.vite',
+    resolve: {
+        alias: {
+            '@': fileURLToPath(new URL('./src', import.meta.url)),
+        },
     },
-    manifest: {
-      name: 'DATEX Workbench',
-      short_name: 'Workbench',
-      description: 'Developer tooling UI for the DATEX runtime',
-      start_url: '/',
-      scope: '/',
-      display: 'standalone',
-      display_override: ['window-controls-overlay'],
-      theme_color: 'oklch(0.145 0 0)',
-      background_color: 'oklch(0.145 0 0))',
-      icons: [
-        { src: '/icon.png', sizes: '192x192', type: 'image/png' },
-        { src: '/icon.png', sizes: '512x512', type: 'image/png' },
-      ],
-    },
-    workbox: {
-      globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
-    },
-  }),
-],
-  cacheDir: 'node_modules/.vite',
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
-    },
-  },
-})
+});


### PR DESCRIPTION
## feat: allow PWA to open .dx and .dxb files in block viewer

When the workbench is installed as a PWA, the OS can now launch it directly to view `.dx` and `.dxb` files:- right-click a file → Open With → DATEX Workbench, and the file loads in the Block Viewer.

### Changes

**`vite.config.ts`** : added `file_handlers` to the PWA manifest:
```ts
file_handlers: [
  {
    action: '/block',
    accept: { 'application/octet-stream': ['.dx', '.dxb'] },
  },
]
```
This registers the PWA with the OS as a handler for `.dx` and `.dxb` files.

**`src/main.ts`** : added a `launchQueue` consumer that runs once at boot. When the OS launches the PWA with a file, the handler reads the file, stashes it in a shared module, and navigates to `/block`.

**`src/lib/pwaLaunch.ts`** (new) : a tiny singleton module that holds the launched file between `main.ts` and the BlockViewer route. Avoids `sessionStorage` serialization of byte arrays.

**`src/views/BlockViewer/DatexBlockProtocolViewWrapper.vue`** : added an `onMounted` hook that picks up the pending file and feeds it through the existing `loadFile` path. Same validation, same error handling : just a different entry point.

### Test

1. `npm run build && npm run preview`
2. Install as PWA in Chrome (desktop)
3. Download a `.dxb` from the workbench (Load example → Save .dxb)
4. Right-click the file → Open With → DATEX Workbench
5. First time, Chrome prompts to allow file handling-> Allow
6. PWA opens at `/block` with the file loaded

### Limitations

- Chromium-based browsers only, desktop only (per the [spec](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/How_to/Associate_files_with_your_PWA))
- Requires the PWA to be installed, doesn't work in a regular browser tab
- First-time use prompts the user to allow file handling