### PR TITLE
feat(i18n): translate global chrome (WelcomeView, SideBar, ThemeSwitch)

### DIFF
--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -5,18 +5,20 @@ import ThemeSwitch from '@/components/ThemeSwitch.vue';
 import IconLogo from '@/components/icons/IconLogo.vue';
 import { Network, SendToBack, Terminal, Box, GitGraph, Cpu, Info } from 'lucide-vue-next';
 import draggable from 'vuedraggable';
+import { useI18n } from 'vue-i18n';
 
+const { t } = useI18n();
 const router = useRouter();
 const route = useRoute();
 
 const sidebarItems = ref([
-    { icon: Terminal, name: 'REPL', path: '/repl' },
-    { icon: Cpu, name: 'ComHub ', path: '/comhub' },
-    { icon: SendToBack, name: 'Network Visualizer ', path: '/network-visualizer' },
-    { icon: Box, name: 'Block Viewer', path: '/block' },
-    { icon: Network, name: 'Network', path: '/network' },
-    { icon: GitGraph, name: 'Node View', path: '/node-view' },
-    { icon: Info, name: 'About', path: '/about' },
+    { icon: Terminal, key: 'nav.repl', path: '/repl' },
+    { icon: Cpu, key: 'nav.comhub', path: '/comhub' },
+    { icon: SendToBack, key: 'nav.networkVisualizer', path: '/network-visualizer' },
+    { icon: Box, key: 'nav.block', path: '/block' },
+    { icon: Network, key: 'nav.network', path: '/network' },
+    { icon: GitGraph, key: 'nav.nodeView', path: '/node-view' },
+    { icon: Info, key: 'nav.about', path: '/about' },
     // { icon: AppWindow, name: 'Windows', path: '/windows' },
     // { icon: MousePointer2, name: 'Pointers', path: '/pointers' },
 ]);
@@ -72,8 +74,7 @@ const navigate = (path: string) => {
                 <div
                     class="card invisible absolute left-14 z-50 m-0 ml-2 whitespace-nowrap px-3 py-1.5 text-xs font-mono shadow-xl group-hover:visible"
                 >
-                    Welcome
-
+                    {{ t('nav.welcome') }}
                     <div
                         class="bg-card border-l border-b border-neutral-200 dark:border-neutral-700 absolute -left-1 top-1/2 h-2 w-2 -translate-y-1/2 rotate-45"
                     ></div>
@@ -82,7 +83,7 @@ const navigate = (path: string) => {
 
             <draggable
                 v-model="sidebarItems"
-                item-key="name"
+                item-key="key"
                 class="flex w-full flex-col items-center gap-4"
                 ghost-class="opacity-20"
                 animation="250"
@@ -111,7 +112,7 @@ const navigate = (path: string) => {
                         <div
                             class="card invisible absolute left-14 z-50 m-0 ml-2 whitespace-nowrap px-3 py-1.5 text-xs font-mono shadow-xl group-hover:visible"
                         >
-                            {{ element.name }}
+                            {{ t(element.key) }}
 
                             <div
                                 class="bg-card border-l border-b border-neutral-200 dark:border-neutral-700 absolute -left-1 top-1/2 h-2 w-2 -translate-y-1/2 rotate-45"

--- a/src/components/ThemeSwitch.vue
+++ b/src/components/ThemeSwitch.vue
@@ -6,10 +6,12 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { useI18n } from 'vue-i18n';
 import { useColorMode } from '@vueuse/core';
 import { Moon, Sun } from 'lucide-vue-next';
 import { watch } from 'vue';
 
+const { t } = useI18n();
 const mode = useColorMode();
 
 // on color mode change, update the meta theme-color
@@ -40,13 +42,13 @@ watch(
                 <Sun
                     class="absolute h-[1.2rem] w-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0"
                 />
-                <span class="sr-only">Toggle theme</span>
+                <span class="sr-only">{{ t('theme.toggle') }}</span>
             </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent class="no-drag ml-2">
-            <DropdownMenuItem @click="mode = 'light'"> Light </DropdownMenuItem>
-            <DropdownMenuItem @click="mode = 'dark'"> Dark </DropdownMenuItem>
-            <DropdownMenuItem @click="mode = 'auto'"> System </DropdownMenuItem>
+            <DropdownMenuItem @click="mode = 'light'"> {{ t('theme.light') }} </DropdownMenuItem>
+            <DropdownMenuItem @click="mode = 'dark'"> {{ t('theme.dark') }} </DropdownMenuItem>
+            <DropdownMenuItem @click="mode = 'auto'"> {{ t('theme.system') }} </DropdownMenuItem>
         </DropdownMenuContent>
     </DropdownMenu>
 </template>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -21,13 +21,23 @@
         "settings": "Einstellungen",
         "language": "Sprache"
     },
+    "theme": {
+        "toggle": "Design umschalten",
+        "light": "Hell",
+        "dark": "Dunkel",
+        "system": "System"
+    },
     "nav": {
+        "welcome": "Willkommen",
         "block": "Block",
         "network": "Netzwerk",
         "nodeView": "Knotenansicht",
         "networkTree": "Netzwerk-Baum",
         "collection": "Sammlung",
-        "about": "Über"
+        "about": "Über",
+        "repl": "REPL",
+        "comhub": "ComHub",
+        "networkVisualizer": "Netzwerk-Visualisierer"
     },
     "block": {
         "openFile": "Datei öffnen",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -21,13 +21,23 @@
         "settings": "Settings",
         "language": "Language"
     },
+    "theme": {
+        "toggle": "Toggle theme",
+        "light": "Light",
+        "dark": "Dark",
+        "system": "System"
+    },
     "nav": {
+        "welcome": "Welcome",
         "block": "Block",
         "network": "Network",
         "nodeView": "Node View",
         "networkTree": "Network Tree",
         "collection": "Collection",
-        "about": "About"
+        "about": "About",
+        "repl": "REPL",
+        "comhub": "ComHub",
+        "networkVisualizer": "Network Visualizer"
     },
     "block": {
         "openFile": "Open File",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -21,13 +21,23 @@
         "settings": "सेटिंग्स",
         "language": "भाषा"
     },
+    "theme": {
+        "toggle": "थीम बदलें",
+        "light": "लाइट",
+        "dark": "डार्क",
+        "system": "सिस्टम"
+    },
     "nav": {
+        "welcome": "स्वागत है",
         "block": "ब्लॉक",
         "network": "नेटवर्क",
         "nodeView": "नोड दृश्य",
         "networkTree": "नेटवर्क ट्री",
         "collection": "संग्रह",
-        "about": "बारे में"
+        "about": "बारे में",
+        "repl": "REPL",
+        "comhub": "ComHub",
+        "networkVisualizer": "नेटवर्क विज़ुअलाइज़र"
     },
     "block": {
         "openFile": "फ़ाइल खोलें",

--- a/src/views/WelcomeView.vue
+++ b/src/views/WelcomeView.vue
@@ -62,7 +62,7 @@ function navigate(route: string | null) {
             <!-- Quick actions -->
             <div class="w-full max-w-2xl">
                 <p class="mb-4 text-xs font-medium uppercase tracking-widest text-muted-foreground">
-                    Quick Actions
+                    {{ t('welcome.quickActions') }}
                 </p>
                 <div class="grid grid-cols-2 gap-3">
                     <button
@@ -146,7 +146,7 @@ function navigate(route: string | null) {
                                 v-if="!action.available"
                                 class="text-xs text-muted-foreground border border-border rounded px-1.5 py-0.5"
                             >
-                                Soon
+                                {{ t('welcome.soon') }}
                             </span>
                             <svg
                                 v-else


### PR DESCRIPTION
## feat(i18n): translate global chrome

First PR in a series to bring i18n coverage to the whole workbench. This one covers the **chrome**, the persistent UI that sits around every view.

### Scope

- `src/views/WelcomeView.vue`: replaced hardcoded `Quick Actions` and `Soon` with `welcome.quickActions` / `welcome.soon` (keys already existed in locale files).
- `src/components/SideBar.vue`: sidebar items now use translation keys (`nav.repl`, `nav.comhub`, `nav.networkVisualizer`, `nav.block`, `nav.network`, `nav.nodeView`, `nav.about`). Welcome tooltip uses `nav.welcome`. Array entries store a `key` instead of `name`; the template translates at render time via `t(element.key)` so labels stay reactive when locale changes: and `draggable` still works because the array itself is unchanged.
- `src/components/ThemeSwitch.vue` : dropdown items and the sr-only label now use a new `theme` namespace (`theme.toggle`, `theme.light`, `theme.dark`, `theme.system`).
- `src/locales/{en,de,hi}.json` : added the `theme` namespace with matching keys in all three locales.

### Files inspected but not changed

- `src/components/HeaderProvider.vue`: only contains product branding (`DATEX Workbench`, `beta`) and a large commented-out menubar block. Branding intentionally stays untranslated; the commented block can be translated when it's re-enabled.
- `src/components/LanguageSwitcher.vue`: only displays locale names (`English`, `Deutsch`, `हिन्दी`), which should appear in their own language regardless of the active locale.
- `src/App.vue`: no user-facing strings.

### Known issue

`HeaderProvider` is currently commented out in `App.vue`, which means `LanguageSwitcher` isn't mounted anywhere in the UI. Locale switching can only be triggered via `localStorage` for now. 

### Translation review

- English: source of truth.
- German: written by me (C1).
- Hindi: written by me as a native speaker. Happy to revise on feedback.

### Test

1. `npm run dev`
2. In DevTools console: `localStorage.setItem('datex-workbench-locale', 'de'); location.reload()`
3. Sidebar tooltips and theme switch dropdown should be in German. Try `'hi'` for Hindi.

### Next PRs

This is the first of a series, plan is one PR per view / component group so each is small and reviewable. Roughly:

- PR 2: BlockViewer view + components
- PR 3: NetworkInspector view + components
- PR 4: NetworkTrace view + components
- PR 5: Editor view + components
- PR 6: ComHub / Endpoint components
- PR 7: Disassembler / Decompiler
- PR 8: misc shared (NodeTree, Pointer*, Window)
- PR 9: smaller views (AboutView, WindowGeneralView, Repl, TreeView)