### PR TITLE
feat(i18n): translate BlockViewer and Disassembler views

### DIFF
--- a/src/components/Disassembler/DisassemblerView.vue
+++ b/src/components/Disassembler/DisassemblerView.vue
@@ -5,6 +5,9 @@ import InstructionTreeNode from './InstructionTreeNode.vue';
 import InstructionFlatItem from './InstructionFlatItem.vue';
 import { GitFork, List, UnfoldVertical, FoldVertical } from 'lucide-vue-next';
 import DecompilerView from '@/components/Decompiler/DecompilerView.vue';
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
 
 const viewType = ref<'disassembler' | 'decompiler'>('disassembler');
 
@@ -54,7 +57,7 @@ const error = computed(() => (viewMode.value === 'tree' ? treeError.value : flat
                     "
                     @click="viewType = 'disassembler'"
                 >
-                    DISASSEMBLER
+                    {{ t('disassembler.disassembler') }}
                 </button>
                 <button
                     class="text-xs font-semibold tracking-wide cursor-pointer"
@@ -65,7 +68,7 @@ const error = computed(() => (viewMode.value === 'tree' ? treeError.value : flat
                     "
                     @click="viewType = 'decompiler'"
                 >
-                    DECOMPILER
+                    {{ t('disassembler.decompiler') }}
                 </button>
             </div>
 
@@ -81,7 +84,7 @@ const error = computed(() => (viewMode.value === 'tree' ? treeError.value : flat
                     @click="viewMode = 'tree'"
                 >
                     <GitFork class="size-3.5" />
-                    Tree
+                    {{ t('disassembler.tree') }}
                 </button>
                 <button
                     class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-xs font-mono cursor-pointer transition-all duration-150"
@@ -93,7 +96,7 @@ const error = computed(() => (viewMode.value === 'tree' ? treeError.value : flat
                     @click="viewMode = 'flat'"
                 >
                     <List class="size-3.5" />
-                    Flat
+                    {{ t('disassembler.flat') }}
                 </button>
 
                 <!-- Separator -->
@@ -111,7 +114,7 @@ const error = computed(() => (viewMode.value === 'tree' ? treeError.value : flat
                 >
                     <UnfoldVertical v-if="showNested" class="size-3.5" />
                     <FoldVertical v-else class="size-3.5" />
-                    Nested
+                    {{ t('disassembler.nested') }}
                 </button>
             </div>
         </div>
@@ -137,7 +140,7 @@ const error = computed(() => (viewMode.value === 'tree' ? treeError.value : flat
 
                 <!-- Empty state -->
                 <div v-else class="text-gray-500 italic text-sm font-mono">
-                    No instructions to display
+                    {{ t('disassembler.noInstructions') }}
                 </div>
             </div>
         </div>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -56,7 +56,9 @@
         "dropOverlay": ".dxb-Datei hier ablegen",
         "loadExample": "Beispielblock laden",
         "fileEmpty": "Datei ist leer",
-        "invalidBlock": "Ungültiger DXB-Block — Magic Number stimmt nicht überein"
+        "invalidBlock": "Ungültiger DXB-Block — Magic Number stimmt nicht überein",
+        "failedToReadFile": "Datei konnte nicht gelesen werden",
+        "failedToLoadExample": "Beispielblock konnte nicht geladen werden"
     },
     "disassembler": {
         "disassembler": "DISASSEMBLER",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -56,7 +56,9 @@
         "dropOverlay": "Drop .dxb file here",
         "loadExample": "Load example block",
         "fileEmpty": "File is empty",
-        "invalidBlock": "Invalid DXB block — magic number mismatch"
+        "invalidBlock": "Invalid DXB block — magic number mismatch",
+        "failedToReadFile": "Failed to read file",
+        "failedToLoadExample": "Failed to load example block"
     },
     "disassembler": {
         "disassembler": "DISASSEMBLER",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -56,7 +56,9 @@
         "dropOverlay": ".dxb फ़ाइल यहाँ छोड़ें",
         "loadExample": "उदाहरण ब्लॉक लोड करें",
         "fileEmpty": "फ़ाइल खाली है",
-        "invalidBlock": "अमान्य DXB ब्लॉक — मैजिक नंबर मेल नहीं खाता"
+        "invalidBlock": "अमान्य DXB ब्लॉक — मैजिक नंबर मेल नहीं खाता",
+        "failedToReadFile": "फ़ाइल पढ़ने में विफल",
+        "failedToLoadExample": "उदाहरण ब्लॉक लोड करने में विफल"
     },
     "disassembler": {
         "disassembler": "डिसअसेंबलर",

--- a/src/views/BlockViewer/BlockProtocolInfoView.vue
+++ b/src/views/BlockViewer/BlockProtocolInfoView.vue
@@ -11,8 +11,11 @@ import {
 import type { FieldIdentifier } from '@/types/BlockViewer/FieldIdentifier';
 import { computed } from 'vue';
 import { X } from 'lucide-vue-next';
+import { useI18n } from 'vue-i18n';
 import { showSubfieldId } from '@/views/BlockViewer/settings';
 import { getColor } from '@/views/BlockViewer/settings';
+
+const { t } = useI18n();
 
 const props = defineProps<{
     structure: ParsedStructure;
@@ -44,8 +47,6 @@ const fieldDef = computed(() => {
     return fd;
 });
 
-// showing the bytes of the magic number not as js array, but also as hex or whatever.
-// Like if there is a big string maybe we'll decide to cut it off later and only expand it on click?!
 function renderParsedValue(value: ParsedValue): string {
     if (value === null) {
         return 'null';
@@ -79,44 +80,46 @@ function renderParsedValue(value: ParsedValue): string {
                 <div class="text-sm" :style="{ color: getColor(fieldDef) }">
                     {{ fieldDef?.category }}
                 </div>
-                <p v-if="'id' in field" class="text-xs">id: {{ field.id }}</p>
+                <p v-if="'id' in field" class="text-xs">{{ t('common.id') }}: {{ field.id }}</p>
             </div>
             <X class="hover:text-muted-foreground size-4 cursor-pointer" @click="closeInfo" />
         </div>
         <div v-if="'parsedValue' in field" class="px-4 py-2 text-base">
-            Value: {{ renderParsedValue(field.parsedValue) }}
+            {{ t('common.value') }}: {{ renderParsedValue(field.parsedValue) }}
         </div>
-        <!-- <p>if possible, description</p> -->
         <div v-if="'subFields' in field" class="text-muted-foreground">
             <Table class="text-base">
-                <!-- <TableCaption>Subfields</TableCaption> -->
                 <TableHeader>
                     <TableRow>
-                        <TableHead class="text-foreground">name</TableHead>
-                        <TableHead class="text-foreground" v-if="showSubfieldId">id</TableHead>
-                        <TableHead class="text-foreground">value</TableHead>
+                        <TableHead class="text-foreground">{{ t('common.name') }}</TableHead>
+                        <TableHead class="text-foreground" v-if="showSubfieldId">
+                            {{ t('common.id') }}
+                        </TableHead>
+                        <TableHead class="text-foreground">{{ t('common.value') }}</TableHead>
                     </TableRow>
                 </TableHeader>
                 <TableBody>
                     <TableRow v-for="(subField, i) in field.subFields" :key="i">
-                        <TableCell class="w-1/3 min-w-max whitespace-nowrap">{{
-                            subField.name
-                        }}</TableCell>
+                        <TableCell class="w-1/3 min-w-max whitespace-nowrap">
+                            {{ subField.name }}
+                        </TableCell>
                         <TableCell
                             v-if="showSubfieldId"
                             class="w-1/3"
                             :class="'id' in subField ? '' : 'brightness-50'"
-                            >{{ 'id' in subField ? subField.id : '-' }}</TableCell
                         >
+                            {{ 'id' in subField ? subField.id : '-' }}
+                        </TableCell>
                         <TableCell
                             class="w-2/3 break-all"
                             :class="{ 'w-1/3': showSubfieldId, 'w-2/3': !showSubfieldId }"
-                            >{{
+                        >
+                            {{
                                 'parsedValue' in subField
                                     ? renderParsedValue(subField.parsedValue)
                                     : '-'
-                            }}</TableCell
-                        >
+                            }}
+                        </TableCell>
                     </TableRow>
                 </TableBody>
             </Table>

--- a/src/views/BlockViewer/DatexBlockProtocolViewWrapper.vue
+++ b/src/views/BlockViewer/DatexBlockProtocolViewWrapper.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { consumePendingLaunchedFile } from '@/lib/pwaLaunch';
 import DatexBlockProtocolView from './DatexBlockProtocolView.vue';
 import { Upload, Download, FileWarning } from 'lucide-vue-next';
 import { parseStructure } from '@unyt/speck';
 import { dxbDefinition } from './settings';
+
+const { t } = useI18n();
 
 const blockData = ref<Uint8Array | null>(null);
 const parseError = ref<string | null>(null);
@@ -17,7 +20,7 @@ async function loadFile(file: File) {
         const buffer = await file.arrayBuffer();
         const data = new Uint8Array(buffer);
         if (data.length === 0) {
-            parseError.value = 'File is empty';
+            parseError.value = t('block.fileEmpty');
             blockData.value = null;
             return;
         }
@@ -25,7 +28,7 @@ async function loadFile(file: File) {
         blockData.value = data;
         fileName.value = file.name;
     } catch (err) {
-        parseError.value = err instanceof Error ? err.message : 'Failed to read file';
+        parseError.value = err instanceof Error ? err.message : t('block.failedToReadFile');
         blockData.value = null;
     }
 }
@@ -80,7 +83,7 @@ async function loadExample() {
         const buffer = await response.arrayBuffer();
         blockData.value = new Uint8Array(buffer);
     } catch {
-        parseError.value = 'Failed to load example block';
+        parseError.value = t('block.failedToLoadExample');
     }
 }
 </script>
@@ -96,7 +99,7 @@ async function loadExample() {
                 class="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs font-mono text-foreground hover:bg-muted transition"
             >
                 <Upload class="size-3.5" />
-                Open File
+                {{ t('block.openFile') }}
                 <input type="file" accept=".dxb,.bin" class="hidden" @change="onFileSelect" />
             </label>
 
@@ -106,7 +109,7 @@ async function loadExample() {
                 @click="saveBlock"
             >
                 <Download class="size-3.5" />
-                Save .dxb
+                {{ t('block.saveBin') }}
             </button>
 
             <span v-if="fileName" class="ml-2 text-xs text-muted-foreground font-mono truncate">
@@ -148,12 +151,14 @@ async function loadExample() {
             <div v-else class="flex flex-col items-center justify-center h-full">
                 <div class="flex flex-col items-center justify-center gap-4 no-drag">
                     <Upload class="size-12 text-muted-foreground" />
-                    <div class="text-muted-foreground text-sm font-mono">Drop a .dxb file here</div>
+                    <div class="text-muted-foreground text-sm font-mono">
+                        {{ t('block.dropOverlay') }}
+                    </div>
                     <label
                         class="inline-flex cursor-pointer items-center gap-2 rounded-md border border-border px-4 py-2 text-sm font-mono text-foreground hover:bg-muted transition"
                     >
                         <Upload class="size-4" />
-                        Open File
+                        {{ t('block.openFile') }}
                         <input
                             type="file"
                             accept=".dxb,.bin"
@@ -166,7 +171,7 @@ async function loadExample() {
                         class="text-xs text-muted-foreground hover:text-foreground underline font-mono"
                         @click="loadExample"
                     >
-                        Load example block
+                        {{ t('block.loadExample') }}
                     </button>
                 </div>
             </div>


### PR DESCRIPTION
Translates BlockViewer top bar/empty state, BlockProtocolInfoView 
(field details, subfield table), and DisassemblerView (mode toggles, 
empty state) using existing block/disassembler namespaces.

New keys:
- common.name, common.id, common.value (reusable table headers)
- block.failedToReadFile, block.failedToLoadExample

Tested locale switching via localStorage in dev, German and Hindi renders 
correctly across all touched views.