### PR TITLE
feat(i18n): translate endpoint, pointer, and comhub views

### DIFF
--- a/src/components/ComHubOverviewWrapper.vue
+++ b/src/components/ComHubOverviewWrapper.vue
@@ -1,23 +1,25 @@
 <template>
     <div class="bg-page flex h-full flex-col overflow-hidden p-5 top-offset">
-        <!-- Title + search + settings -->
         <div class="mb-4 flex items-center gap-2">
             <h2 class="mr-2 text-lg font-semibold text-neutral-900 dark:text-neutral-100">
                 ComHub
             </h2>
 
-            <!-- Settings gear -->
-            <!-- Settings Popover -->
             <Popover>
                 <PopoverTrigger as-child>
-                    <Button variant="outline" size="icon" title="Settings" class="btn-icon">
+                    <Button
+                        variant="outline"
+                        size="icon"
+                        :title="t('common.settings')"
+                        class="btn-icon"
+                    >
                         <Settings class="h-4 w-4" />
                     </Button>
                 </PopoverTrigger>
                 <PopoverContent align="start" class="w-52">
                     <div class="flex flex-col gap-3 p-1">
                         <div class="flex items-center justify-between">
-                            <span class="text-dim text-sm">Advanced Mode</span>
+                            <span class="text-dim text-sm">{{ t('comhub.advancedMode') }}</span>
                             <button
                                 role="switch"
                                 :aria-checked="advancedMode"
@@ -36,7 +38,7 @@
                             </button>
                         </div>
                         <div class="flex items-center justify-between">
-                            <span class="text-dim text-sm">Group by Endpoint</span>
+                            <span class="text-dim text-sm">{{ t('comhub.groupByEndpoint') }}</span>
                             <button
                                 role="switch"
                                 :aria-checked="groupByEndpoint"
@@ -58,18 +60,16 @@
                 </PopoverContent>
             </Popover>
 
-            <!-- Search bar -->
             <div class="max-w-[400px] flex-1">
                 <input
                     v-model="searchQuery"
                     type="text"
-                    placeholder="Search (e.g. @example)"
+                    :placeholder="t('comhub.searchPlaceholder')"
                     class="bg-card text-primary w-full rounded border border-neutral-300 px-3 py-2 text-sm placeholder-neutral-400 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-neutral-600 dark:placeholder-neutral-500"
                 />
             </div>
         </div>
 
-        <!-- List -->
         <div class="flex-1 overflow-y-auto no-drag">
             <ComHubEndpointList
                 v-if="groupByEndpoint"
@@ -89,12 +89,15 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { getComHubMetadata } from '@/lib/runtime';
 import ComHubInterfaceList from '@/components/ComHubInterfaceList.vue';
 import ComHubEndpointList from '@/components/ComHubEndpointList.vue';
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
 import { Settings } from 'lucide-vue-next';
+
+const { t } = useI18n();
 
 interface InterfaceProperties {
     name?: string;
@@ -131,7 +134,6 @@ const advancedMode = ref(false);
 const groupByEndpoint = ref(false);
 const interfaces = ref<ComHubInterface[]>([]);
 
-// Don't treat bare '@' as a valid search
 const effectiveSearch = computed(() => {
     const q = searchQuery.value.trim();
     if (q === '@') return '';

--- a/src/components/PointerPreferences.vue
+++ b/src/components/PointerPreferences.vue
@@ -3,8 +3,10 @@ import { usePointerPreferences } from '@/composable/usePointerPreferences';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
 import { PopoverContent } from '@/components/ui/popover';
+import { useI18n } from 'vue-i18n';
 
 const { preferences, resetPreferences } = usePointerPreferences();
+const { t } = useI18n();
 </script>
 
 <template>
@@ -13,9 +15,9 @@ const { preferences, resetPreferences } = usePointerPreferences();
             <!-- Header -->
             <div class="flex items-center justify-between">
                 <div class="space-y-1">
-                    <h4 class="leading-none font-medium">Display Preferences</h4>
+                    <h4 class="leading-none font-medium">{{ t('pointer.displayPreferences') }}</h4>
                     <p class="text-muted-foreground text-sm">
-                        Customize how pointers are displayed
+                        {{ t('pointer.customizeDisplay') }}
                     </p>
                 </div>
                 <Button
@@ -24,55 +26,55 @@ const { preferences, resetPreferences } = usePointerPreferences();
                     @click="resetPreferences"
                     class="h-8 px-2 text-xs"
                 >
-                    Reset
+                    {{ t('common.reset') }}
                 </Button>
             </div>
 
             <!-- Preferences List -->
             <div class="space-y-4">
-                <!-- Show Full Pointer IDs -->
                 <div class="flex items-center justify-between space-x-2">
                     <div class="flex flex-1 flex-col space-y-1">
-                        <label class="cursor-pointer text-sm font-medium"> Full Pointer IDs </label>
+                        <label class="cursor-pointer text-sm font-medium">
+                            {{ t('pointer.fullPointerIds') }}
+                        </label>
                         <span class="text-muted-foreground text-xs">
-                            Show complete pointer identifiers instead of shortened versions
+                            {{ t('pointer.fullPointerIdsDesc') }}
                         </span>
                     </div>
                     <Switch v-model="preferences.show_full_pointer_ids" id="show-full-ids" />
                 </div>
 
-                <!-- Show Type Hints -->
                 <div class="flex items-center justify-between space-x-2">
                     <div class="flex flex-1 flex-col space-y-1">
-                        <label class="cursor-pointer text-sm font-medium"> Type Hints </label>
+                        <label class="cursor-pointer text-sm font-medium">
+                            {{ t('pointer.typeHints') }}
+                        </label>
                         <span class="text-muted-foreground text-xs">
-                            Display type annotations for values
+                            {{ t('pointer.typeHintsDesc') }}
                         </span>
                     </div>
                     <Switch v-model="preferences.show_type_hints" id="show-type-hints" />
                 </div>
 
-                <!-- Show Array Indices -->
                 <div class="flex items-center justify-between space-x-2">
                     <div class="flex flex-1 flex-col space-y-1">
                         <label class="cursor-pointer text-sm font-medium">
-                            Array Indices & Keys
+                            {{ t('pointer.arrayIndicesKeys') }}
                         </label>
                         <span class="text-muted-foreground text-xs">
-                            Show array indices and object keys
+                            {{ t('pointer.arrayIndicesKeysDesc') }}
                         </span>
                     </div>
                     <Switch v-model="preferences.show_array_indicies" id="show-array-indices" />
                 </div>
 
-                <!-- Hide Type Hints for Primitives -->
                 <div class="flex items-center justify-between space-x-2">
                     <div class="flex flex-1 flex-col space-y-1">
                         <label class="cursor-pointer text-sm font-medium">
-                            Hide Primitive Type Hints
+                            {{ t('pointer.hidePrimitiveTypeHints') }}
                         </label>
                         <span class="text-muted-foreground text-xs">
-                            Hide type hints for integers, booleans, and text (show for maps/arrays)
+                            {{ t('pointer.hidePrimitiveTypeHintsDesc') }}
                         </span>
                     </div>
                     <Switch
@@ -81,14 +83,13 @@ const { preferences, resetPreferences } = usePointerPreferences();
                     />
                 </div>
 
-                <!-- Hide Map Key Type Hints for Primitives -->
                 <div class="flex items-center justify-between space-x-2">
                     <div class="flex flex-1 flex-col space-y-1">
                         <label class="cursor-pointer text-sm font-medium">
-                            Hide Map Key Primitive Type Hints
+                            {{ t('pointer.hideMapKeyPrimitiveTypeHints') }}
                         </label>
                         <span class="text-muted-foreground text-xs">
-                            Hide type hints for primitive map keys (text, integer, boolean)
+                            {{ t('pointer.hideMapKeyPrimitiveTypeHintsDesc') }}
                         </span>
                     </div>
                     <Switch

--- a/src/components/PointerRefInline.vue
+++ b/src/components/PointerRefInline.vue
@@ -4,6 +4,9 @@ import { usePointerPreferences } from '@/composable/usePointerPreferences';
 import { getTypeName } from '@/lib/pointer-types';
 import type { DIF } from '@unyt/datex';
 import { computed, inject } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
 
 // Props
 interface PointerRefInlineProps {
@@ -89,9 +92,9 @@ function handleClick() {
             <TooltipContent>
                 <p class="font-mono text-xs">{{ pointerId }}</p>
                 <p v-if="valuePreview" class="text-muted-foreground text-xs">
-                    Value: {{ valuePreview }}
+                    {{ t('common.value') }}: {{ valuePreview }}
                 </p>
-                <p class="text-muted-foreground mt-1 text-xs">Click to jump to definition</p>
+                <p class="text-muted-foreground mt-1 text-xs">{{ t('pointer.clickToJump') }}</p>
             </TooltipContent>
         </Tooltip>
     </TooltipProvider>

--- a/src/components/PointerTreeItem.vue
+++ b/src/components/PointerTreeItem.vue
@@ -4,6 +4,7 @@ import { TYPE_CONFIGS, extractPointerId, getTypeName } from '@/lib/pointer-types
 import type { DIF } from '@unyt/datex';
 import { ChevronDown, ChevronRight } from 'lucide-vue-next';
 import { computed, nextTick, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 import PointerRefInline from './PointerRefInline.vue';
 
 // Props
@@ -19,9 +20,9 @@ interface PointerTreeItemProps {
     hideTypeHintsForPrimitives?: boolean;
     hideMapKeyTypeHintsForPrimitives?: boolean;
     depth?: number;
-    parentIsMap?: boolean; // Track if parent is a map
-    keyContainer?: DIF.Definitions.DIFValueContainer; // The original DIF container for the key (for type hints)
-    selectedPointerId?: string | null; // For highlighting navigated pointer
+    parentIsMap?: boolean;
+    keyContainer?: DIF.Definitions.DIFValueContainer;
+    selectedPointerId?: string | null;
 }
 
 const props = withDefaults(defineProps<PointerTreeItemProps>(), {
@@ -36,7 +37,8 @@ const props = withDefaults(defineProps<PointerTreeItemProps>(), {
     selectedPointerId: null,
 });
 
-// Emits
+const { t } = useI18n();
+
 const emit = defineEmits<{
     'node-click': [nodeId: string, value: DIF.Definitions.DIFValueContainer];
     'node-toggle': [nodeId: string];
@@ -45,28 +47,22 @@ const emit = defineEmits<{
     'value-update': [nodeId: string, newValue: unknown];
 }>();
 
-// Editing state
 const isEditing = ref(false);
 const editValue = ref('');
 const editInputRef = ref<HTMLInputElement | null>(null);
 
-// Check if value is circular reference
 function isCircularReference(difValueContainer: DIF.Definitions.DIFValueContainer): boolean {
-    // Only objects can have circular references
     if (typeof difValueContainer !== 'object' || difValueContainer === null) {
         return false;
     }
-
     return props.visitedObjects?.has(difValueContainer) ?? false;
 }
 
-// Check if expandable
 function isExpandable(difValueContainer: DIF.Definitions.DIFValueContainer): boolean {
     const typeName = getTypeName(difValueContainer);
     return TYPE_CONFIGS[typeName]?.isExpandable ?? false;
 }
 
-// Extract the actual value from a DIF container, unwrapping nested value properties
 function extractValue(difValueContainer: DIF.Definitions.DIFValueContainer): unknown {
     if (
         difValueContainer &&
@@ -78,15 +74,12 @@ function extractValue(difValueContainer: DIF.Definitions.DIFValueContainer): unk
     return difValueContainer;
 }
 
-// Get value preview
 function getValuePreview(difValueContainer: DIF.Definitions.DIFValueContainer): string {
     const value = extractValue(difValueContainer);
     const typeName = getTypeName(difValueContainer);
 
-    // Build the preview string
     let preview = '';
 
-    // Determine if we should show type hint
     const shouldShowTypeHint =
         props.showDataTypes &&
         !(
@@ -97,12 +90,10 @@ function getValuePreview(difValueContainer: DIF.Definitions.DIFValueContainer): 
                 typeName === 'text')
         );
 
-    // Add data type if conditions are met
     if (shouldShowTypeHint) {
         preview = `${typeName} = `;
     }
 
-    // For non-expandable types, show the actual value
     if (!TYPE_CONFIGS[typeName]?.isExpandable) {
         if (typeName === 'text') preview += `"${value}"`;
         else if (typeName === 'boolean') preview += value ? 'true' : 'false';
@@ -116,21 +107,17 @@ function getValuePreview(difValueContainer: DIF.Definitions.DIFValueContainer): 
     return preview;
 }
 
-// Get children
 function getChildren(
     difValueContainer: DIF.Definitions.DIFValueContainer,
 ): Array<[string, DIF.Definitions.DIFValueContainer, DIF.Definitions.DIFValueContainer?]> {
-    // Only compute children if node is expanded (lazy evaluation)
     if (!expanded.value) {
         return [];
     }
 
-    // Check for circular reference before processing children
     if (isCircularReference(difValueContainer)) {
         return [];
     }
 
-    // Check if it's a DIF map type (type: '0c0000')
     if (
         typeof difValueContainer === 'object' &&
         difValueContainer !== null &&
@@ -139,10 +126,8 @@ function getChildren(
     ) {
         const value = extractValue(difValueContainer);
 
-        // DIF maps can be stored as an array of [key, value] tuples (DIFMap format)
         if (Array.isArray(value)) {
             return (value as DIF.Definitions.DIFMap).map(([keyContainer, valueContainer]) => {
-                // Extract the display value for the key
                 const keyValue = extractValue(keyContainer);
                 const keyDisplay =
                     typeof keyValue === 'string'
@@ -156,24 +141,16 @@ function getChildren(
             });
         }
 
-        // DIF maps can also be stored as an object with key-value pairs
         if (typeof value === 'object' && value !== null) {
             return Object.entries(value).map(([k, v]) => {
-                // Create a DIFValueContainer for the key
-                // Try to infer the actual type from the key string
                 let keyValue: string | number | boolean = k;
 
-                // Try to parse as number
                 if (!isNaN(Number(k)) && k.trim() !== '') {
                     keyValue = Number(k);
-                }
-                // Try to parse as boolean
-                else if (k === 'true' || k === 'false') {
+                } else if (k === 'true' || k === 'false') {
                     keyValue = k === 'true';
                 }
 
-                // Create container with the properly typed value
-                // getTypeName() will infer the correct type from the value
                 const keyContainer: DIF.Definitions.DIFValueContainer = { value: keyValue };
                 return [k, v as DIF.Definitions.DIFValueContainer, keyContainer];
             });
@@ -208,7 +185,6 @@ function getChildren(
         );
     }
 
-    // Handle plain JavaScript objects
     if (
         typeof difValueContainer === 'object' &&
         difValueContainer !== null &&
@@ -224,10 +200,8 @@ function getChildren(
     return [];
 }
 
-// Computed children list (cached and only recomputes when expanded or value changes)
 const children = computed(() => getChildren(props.value));
 
-// Create new visited set for children (includes current value)
 const childVisitedObjects = computed(() => {
     const newVisited = new WeakSet<object>();
     if (typeof props.value === 'object' && props.value !== null) {
@@ -236,12 +210,10 @@ const childVisitedObjects = computed(() => {
     return newVisited;
 });
 
-// Generate child ID
 function getChildId(parentId: string, childKey: string): string {
     return `${parentId}.${childKey}`;
 }
 
-// Get the type hint for a key (used for map keys)
 function getKeyTypeHint(keyContainer?: DIF.Definitions.DIFValueContainer): string {
     if (!keyContainer || !props.showDataTypes) {
         return '';
@@ -249,7 +221,6 @@ function getKeyTypeHint(keyContainer?: DIF.Definitions.DIFValueContainer): strin
 
     const typeName = getTypeName(keyContainer);
 
-    // Apply the same logic for hiding type hints for primitives, but using the map key preference
     const shouldShowTypeHint = !(
         props.hideMapKeyTypeHintsForPrimitives &&
         (typeName === 'integer' ||
@@ -261,39 +232,32 @@ function getKeyTypeHint(keyContainer?: DIF.Definitions.DIFValueContainer): strin
     return shouldShowTypeHint ? typeName : '';
 }
 
-// Get tooltip content for keys
 function getKeyTooltip(keyContainer?: DIF.Definitions.DIFValueContainer): string {
     if (!keyContainer) return '';
     const typeName = getTypeName(keyContainer);
-    return `Key Type: ${typeName}`;
+    return `${t('pointer.keyType')}: ${typeName}`;
 }
 
-// Get tooltip content for values
 function getValueTooltip(valueContainer: DIF.Definitions.DIFValueContainer): string {
     const typeName = getTypeName(valueContainer);
-    const parts: string[] = [`Type: ${typeName}`];
+    const parts: string[] = [`${t('common.type')}: ${typeName}`];
 
-    // Add pointer ID if it's a pointer address (string format like $0000000000000001)
     if (typeof valueContainer === 'string' && valueContainer.startsWith('$')) {
-        parts.push(`Pointer: ${valueContainer}`);
+        parts.push(`${t('pointer.pointer')}: ${valueContainer}`);
     }
 
     return parts.join('\n');
 }
 
-// Computed
 const expanded = computed(() => props.expandedNodes.has(props.nodeId));
 
-// Check if current value is circular
 const isCircular = computed(() => isCircularReference(props.value));
 
-// Check if current value is a map (so we can pass this info to children)
 const isMap = computed(() => {
     const typeName = getTypeName(props.value);
     return typeName === 'map';
 });
 
-// Methods
 function toggleExpanded(event?: Event) {
     if (event) {
         event.stopPropagation();
@@ -302,7 +266,6 @@ function toggleExpanded(event?: Event) {
 }
 
 function handleClick() {
-    // Click on the row toggles expansion if expandable
     if (isExpandable(props.value)) {
         toggleExpanded();
     } else {
@@ -310,9 +273,7 @@ function handleClick() {
     }
 }
 
-// Editing functions
 function startEditing() {
-    // Only allow editing for primitive values (not expandable)
     if (isExpandable(props.value) || extractPointerId(props.value) || isCircular.value) {
         return;
     }
@@ -320,7 +281,6 @@ function startEditing() {
     const value = extractValue(props.value);
     const typeName = getTypeName(props.value);
 
-    // Set initial edit value based on type
     if (typeName === 'text') {
         editValue.value = String(value);
     } else if (typeName === 'boolean') {
@@ -330,12 +290,11 @@ function startEditing() {
     } else if (typeName === 'null') {
         editValue.value = 'null';
     } else {
-        return; // Don't allow editing other types
+        return;
     }
 
     isEditing.value = true;
 
-    // Focus input after render
     nextTick(() => {
         if (editInputRef.value) {
             editInputRef.value.focus();
@@ -351,7 +310,6 @@ function saveEdit() {
     let newValue: unknown;
 
     try {
-        // Parse the new value based on type
         if (typeName === 'text') {
             newValue = editValue.value;
         } else if (typeName === 'boolean') {
@@ -378,7 +336,6 @@ function saveEdit() {
         emit('value-update', props.nodeId, newValue);
         isEditing.value = false;
     } catch {
-        // On error, cancel editing
         cancelEdit();
     }
 }
@@ -421,7 +378,6 @@ function handleEditKeydown(event: KeyboardEvent) {
             }"
             @click="handleClick"
         >
-            <!-- Expand/Collapse chevron -->
             <button
                 v-if="isExpandable(value)"
                 @click="toggleExpanded"
@@ -432,9 +388,7 @@ function handleEditKeydown(event: KeyboardEvent) {
             </button>
             <div v-else :class="depth === 0 ? 'w-5' : 'w-4'" class="shrink-0"></div>
 
-            <!-- Content -->
             <div class="flex min-w-0 flex-1 items-center gap-2">
-                <!-- For top-level pointers (depth 0): show pointer ID in blue -->
                 <TooltipProvider v-if="depth === 0" :delay-duration="300">
                     <Tooltip>
                         <TooltipTrigger as-child>
@@ -448,8 +402,6 @@ function handleEditKeydown(event: KeyboardEvent) {
                     </Tooltip>
                 </TooltipProvider>
 
-                <!-- For nested items (depth > 0): show key -->
-                <!-- Always show keys for map entries, only show for arrays/lists if showIndices is true -->
                 <TooltipProvider
                     v-if="depth > 0 && (parentIsMap || showIndices)"
                     :delay-duration="300"
@@ -457,7 +409,6 @@ function handleEditKeydown(event: KeyboardEvent) {
                     <Tooltip>
                         <TooltipTrigger as-child>
                             <span class="text-sm font-medium">
-                                <!-- Show key type hint if available -->
                                 <span
                                     v-if="
                                         keyContainer &&
@@ -477,23 +428,19 @@ function handleEditKeydown(event: KeyboardEvent) {
                     </Tooltip>
                 </TooltipProvider>
 
-                <!-- Show circular reference indicator -->
                 <span v-if="isCircular" class="text-sm text-amber-500 italic">
-                    [Circular Reference]
+                    {{ t('pointer.circularReference') }}
                 </span>
 
-                <!-- Show pointer reference as clickable chip -->
                 <PointerRefInline
                     v-else-if="extractPointerId(value)"
                     :pointer-id="extractPointerId(value)!"
                     @click="emit('pointer-ref-click', extractPointerId(value)!)"
                 />
 
-                <!-- Show type-based preview or opening bracket when expanded -->
                 <TooltipProvider v-else-if="!expanded || depth === 0" :delay-duration="300">
                     <Tooltip>
                         <TooltipTrigger as-child>
-                            <!-- Editable value -->
                             <div v-if="isEditing" @click.stop class="flex-1">
                                 <input
                                     ref="editInputRef"
@@ -503,7 +450,6 @@ function handleEditKeydown(event: KeyboardEvent) {
                                     class="bg-background border-primary focus:ring-primary w-full rounded border px-1 py-0.5 text-sm focus:ring-1 focus:outline-none"
                                 />
                             </div>
-                            <!-- Display value -->
                             <span
                                 v-else
                                 @dblclick.stop="startEditing"
@@ -514,7 +460,9 @@ function handleEditKeydown(event: KeyboardEvent) {
                         </TooltipTrigger>
                         <TooltipContent>
                             <p class="text-xs whitespace-pre-line">{{ getValueTooltip(value) }}</p>
-                            <p class="text-muted-foreground mt-1 text-xs">Double-click to edit</p>
+                            <p class="text-muted-foreground mt-1 text-xs">
+                                {{ t('pointer.doubleClickToEdit') }}
+                            </p>
                         </TooltipContent>
                     </Tooltip>
                 </TooltipProvider>
@@ -524,7 +472,6 @@ function handleEditKeydown(event: KeyboardEvent) {
             </div>
         </div>
 
-        <!-- Children (RECURSIVE - this component calls itself!) -->
         <div
             v-if="expanded && isExpandable(value) && !isCircular"
             class="border-border ml-6 border-l pl-1"
@@ -552,7 +499,6 @@ function handleEditKeydown(event: KeyboardEvent) {
                 @value-update="emit('value-update', $event, $event)"
             />
 
-            <!-- Closing bracket -->
             <div class="text-foreground/70 px-1 py-2 text-sm">
                 {{ getTypeName(value) === 'list' ? ']' : '}' }}
             </div>

--- a/src/components/PointerView.vue
+++ b/src/components/PointerView.vue
@@ -18,6 +18,7 @@ import type { DIF } from '@unyt/datex';
 import { Filter, Search, Settings } from 'lucide-vue-next';
 import type { HTMLAttributes } from 'vue';
 import { computed, nextTick, provide, ref, watchEffect } from 'vue';
+import { useI18n } from 'vue-i18n';
 import PointerPreferences from './PointerPreferences.vue';
 import PointerTreeItem from './PointerTreeItem.vue';
 
@@ -30,10 +31,17 @@ interface PointerViewProps {
 
 // Define props with defaults
 const props = withDefaults(defineProps<PointerViewProps>(), {
-    searchPlaceholder: 'Search...',
+    searchPlaceholder: undefined,
     visitedObjects: new WeakSet(),
 });
 console.log(props);
+
+const { t } = useI18n();
+
+const effectivePlaceholder = computed(
+    () => props.searchPlaceholder ?? t('common.searchPlaceholder'),
+);
+
 // Emits to communicate with parent
 const emit = defineEmits<{
     'pointer-click': [pointerId: string, value: DIF.Definitions.DIFValueContainer];
@@ -181,8 +189,6 @@ function jumpToPointer(pointerId: string) {
 function handleValueUpdate(nodeId: string, newValue: unknown) {
     console.log('Value updated:', nodeId, newValue);
     // TODO: Update the actual pointer value in the runtime
-    // This would require integration with the DATEX runtime to persist changes
-    // For now, just log the update
 }
 
 // Toggle type filter
@@ -215,7 +221,7 @@ function resetTypeFilters() {
                             <Button
                                 variant="outline"
                                 size="icon"
-                                title="Display Preferences"
+                                :title="t('pointer.displayPreferences')"
                                 class="btn-icon"
                             >
                                 <Settings class="h-4 w-4" />
@@ -232,7 +238,7 @@ function resetTypeFilters() {
                         <Input
                             v-model="searchQuery"
                             type="text"
-                            :placeholder="props.searchPlaceholder"
+                            :placeholder="effectivePlaceholder"
                             class="pl-9"
                         />
                     </div>
@@ -246,7 +252,7 @@ function resetTypeFilters() {
                         </DropdownMenuTrigger>
 
                         <DropdownMenuContent align="end" class="w-56">
-                            <DropdownMenuLabel>Filter by Type</DropdownMenuLabel>
+                            <DropdownMenuLabel>{{ t('pointer.filterByType') }}</DropdownMenuLabel>
                             <DropdownMenuSeparator />
 
                             <DropdownMenuCheckboxItem
@@ -277,7 +283,7 @@ function resetTypeFilters() {
                                     class="w-full"
                                     @click="resetTypeFilters"
                                 >
-                                    Reset Filters
+                                    {{ t('pointer.resetFilters') }}
                                 </Button>
                             </div>
                         </DropdownMenuContent>
@@ -323,8 +329,8 @@ function resetTypeFilters() {
                         >
                             {{
                                 props.pointers.size === 0
-                                    ? 'No pointers available'
-                                    : 'No pointers match selected filters'
+                                    ? t('pointer.noPointersAvailable')
+                                    : t('pointer.noPointersMatchFilters')
                             }}
                         </div>
                     </SidebarMenu>

--- a/src/components/endpoint/EndpointFingerprint.vue
+++ b/src/components/endpoint/EndpointFingerprint.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 interface Props {
     fingerprint?: string;
@@ -8,8 +9,10 @@ interface Props {
 
 const props = defineProps<Props>();
 
+const { t } = useI18n();
+
 const fingerprintText = computed(() => {
-    if (!props.fingerprint) return 'Unavailable';
+    if (!props.fingerprint) return t('common.unavailable');
 
     if (typeof props.fingerprint === 'string') {
         return props.fingerprint;
@@ -41,7 +44,7 @@ const downloadFingerprint = () => {
 
 <template>
     <section class="flex flex-col gap-2">
-        <h2 class="text-primary text-sm font-medium">Fingerprint</h2>
+        <h2 class="text-primary text-sm font-medium">{{ t('endpoint.fingerprint') }}</h2>
 
         <div class="bg-subtle flex items-start justify-between gap-3 rounded p-3">
             <pre class="text-primary text-xs break-all whitespace-pre-wrap"
@@ -54,7 +57,7 @@ const downloadFingerprint = () => {
                 :disabled="!props.fingerprint"
                 @click="downloadFingerprint"
             >
-                Download
+                {{ t('common.download') }}
             </button>
         </div>
     </section>

--- a/src/components/endpoint/EndpointInterfaces.vue
+++ b/src/components/endpoint/EndpointInterfaces.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+
 interface InterfaceProperties {
     interface_type?: string;
     channel?: string;
@@ -21,9 +23,10 @@ interface Props {
 
 defineProps<Props>();
 
-// Add this helper in <script setup>:
+const { t } = useI18n();
+
 function formatBandwidth(value: number): string {
-    if (value === 4294967295) return 'Unlimited';
+    if (value === 4294967295) return t('common.unlimited');
     if (value >= 1000) return `${(value / 1000).toFixed(1)} kbps`;
     return `${value} bps`;
 }
@@ -31,10 +34,10 @@ function formatBandwidth(value: number): string {
 
 <template>
     <section class="flex flex-col gap-3">
-        <h2 class="text-sm font-medium">Public Interfaces</h2>
+        <h2 class="text-sm font-medium">{{ t('endpoint.publicInterfaces') }}</h2>
 
         <div v-if="!interfaces || interfaces.length === 0" class="text-sm text-neutral-500 italic">
-            No public interfaces exposed by this endpoint.
+            {{ t('endpoint.noPublicInterfaces') }}
         </div>
 
         <div v-else class="flex flex-col gap-2">
@@ -43,7 +46,6 @@ function formatBandwidth(value: number): string {
                 :key="iface.uuid"
                 class="rounded bg-neutral-100 p-3 text-sm dark:bg-neutral-800"
             >
-                <!-- Interface Header -->
                 <div class="flex flex-col gap-1">
                     <div class="font-medium">
                         {{ iface.properties?.name || iface.uuid }}
@@ -54,23 +56,22 @@ function formatBandwidth(value: number): string {
                     </div>
                 </div>
 
-                <!-- Properties Grid (clean + reviewer-friendly) -->
                 <div
                     v-if="iface.properties"
                     class="mt-3 grid grid-cols-2 gap-x-4 gap-y-1 text-xs md:grid-cols-3"
                 >
                     <div v-if="iface.properties.interface_type">
-                        <span class="text-neutral-500">Type:</span>
+                        <span class="text-neutral-500">{{ t('common.type') }}:</span>
                         {{ iface.properties.interface_type }}
                     </div>
 
                     <div v-if="iface.properties.channel">
-                        <span class="text-neutral-500">Channel:</span>
+                        <span class="text-neutral-500">{{ t('endpoint.channel') }}:</span>
                         {{ iface.properties.channel }}
                     </div>
 
                     <div v-if="iface.properties.direction">
-                        <span class="text-neutral-500">Direction:</span>
+                        <span class="text-neutral-500">{{ t('endpoint.direction') }}:</span>
                         {{ iface.properties.direction }}
                     </div>
 
@@ -80,17 +81,16 @@ function formatBandwidth(value: number): string {
                     </div>
 
                     <div v-if="iface.properties.max_bandwidth !== undefined">
-                        <span class="text-neutral-500">Max Bandwidth:</span>
+                        <span class="text-neutral-500">{{ t('endpoint.maxBandwidth') }}:</span>
                         {{ formatBandwidth(iface.properties.max_bandwidth) }}
                     </div>
                 </div>
 
-                <!-- Waiting state -->
                 <div
                     v-if="iface.is_waiting_for_socket_connections"
                     class="mt-2 text-xs text-amber-500"
                 >
-                    Waiting for socket connections…
+                    {{ t('endpoint.waitingForSockets') }}
                 </div>
             </div>
         </div>

--- a/src/components/endpoint/EndpointPointers.vue
+++ b/src/components/endpoint/EndpointPointers.vue
@@ -1,8 +1,12 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
+</script>
 
 <template>
     <section class="flex flex-col gap-3">
-        <h2 class="text-primary text-sm font-medium">Pointer View</h2>
-        <div class="text-dim text-sm italic">No pointers currently loaded in the runtime.</div>
+        <h2 class="text-primary text-sm font-medium">{{ t('endpoint.pointerView') }}</h2>
+        <div class="text-dim text-sm italic">{{ t('endpoint.noPointersLoaded') }}</div>
     </section>
 </template>

--- a/src/components/endpoint/EndpointView.vue
+++ b/src/components/endpoint/EndpointView.vue
@@ -6,6 +6,9 @@ import EndpointFingerprint from '@/components/endpoint/EndpointFingerprint.vue';
 import EndpointPointers from '@/components/endpoint/EndpointPointers.vue';
 import EndpointInterfaces from '@/components/endpoint/EndpointInterfaces.vue';
 import { Datex } from '@/lib/runtime';
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
 
 interface InterfaceProperties {
     name?: string;
@@ -117,7 +120,7 @@ const tagStyles: Record<EndpointTag, string> = {
                     {{ endpoint.description }}
                 </p>
                 <p v-if="endpoint.profile" class="text-faint text-xs">
-                    Profile: {{ endpoint.profile }}
+                    {{ t('endpoint.profile') }}: {{ endpoint.profile }}
                 </p>
             </section>
 
@@ -141,7 +144,9 @@ const tagStyles: Record<EndpointTag, string> = {
             <section
                 class="bg-card flex flex-col gap-2 rounded-lg border border-neutral-200 p-4 dark:border-neutral-700"
             >
-                <h2 class="text-primary text-sm font-medium">Public Interfaces</h2>
+                <h2 class="text-primary text-sm font-medium">
+                    {{ t('endpoint.publicInterfaces') }}
+                </h2>
                 <EndpointInterfaces :interfaces="endpoint?.interfaces ?? []" />
             </section>
 
@@ -151,7 +156,7 @@ const tagStyles: Record<EndpointTag, string> = {
                 class="flex flex-col gap-2 rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-900"
             >
                 <h2 class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                    Documentation
+                    {{ t('endpoint.documentation') }}
                 </h2>
                 <EndpointDocs :markdown="endpoint.documentation" />
             </section>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -85,7 +85,7 @@
         "notSigned": "Nicht signiert"
     },
     "trace": {
-        "endpoint": "@endpunkt",
+        "endpoint": "\\@endpunkt",
         "timeout": "Zeitüberschreitung (ms)",
         "trace": "Verfolgen",
         "tracing": "Verfolgt...",
@@ -153,6 +153,6 @@
     "comhub": {
         "advancedMode": "Erweiterter Modus",
         "groupByEndpoint": "Nach Endpunkt gruppieren",
-        "searchPlaceholder": "Suchen (z. B. @beispiel)"
+        "searchPlaceholder": "Suchen (z. B. \\@beispiel)"
     }
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -113,5 +113,46 @@
         "jsVersion": "JS-Version",
         "endpoint": "Endpunkt",
         "activeFeatures": "Aktive Funktionen"
+    },
+    "endpoint": {
+        "fingerprint": "Fingerabdruck",
+        "publicInterfaces": "Öffentliche Schnittstellen",
+        "noPublicInterfaces": "Dieser Endpunkt stellt keine öffentlichen Schnittstellen bereit.",
+        "channel": "Kanal",
+        "direction": "Richtung",
+        "maxBandwidth": "Max. Bandbreite",
+        "waitingForSockets": "Warte auf Socket-Verbindungen…",
+        "profile": "Profil",
+        "documentation": "Dokumentation",
+        "pointerView": "Pointer-Ansicht",
+        "noPointersLoaded": "Keine Pointer derzeit in der Runtime geladen."
+    },
+    "pointer": {
+        "displayPreferences": "Anzeigeeinstellungen",
+        "filterByType": "Nach Typ filtern",
+        "resetFilters": "Filter zurücksetzen",
+        "noPointersAvailable": "Keine Pointer verfügbar",
+        "noPointersMatchFilters": "Keine Pointer entsprechen den gewählten Filtern",
+        "clickToJump": "Klicken, um zur Definition zu springen",
+        "customizeDisplay": "Anpassen, wie Pointer angezeigt werden",
+        "fullPointerIds": "Vollständige Pointer-IDs",
+        "fullPointerIdsDesc": "Vollständige Pointer-Kennungen statt verkürzter Versionen anzeigen",
+        "typeHints": "Typhinweise",
+        "typeHintsDesc": "Typannotationen für Werte anzeigen",
+        "arrayIndicesKeys": "Array-Indizes & Schlüssel",
+        "arrayIndicesKeysDesc": "Array-Indizes und Objektschlüssel anzeigen",
+        "hidePrimitiveTypeHints": "Primitive Typhinweise ausblenden",
+        "hidePrimitiveTypeHintsDesc": "Typhinweise für Integer, Booleans und Text ausblenden (für Maps/Arrays anzeigen)",
+        "hideMapKeyPrimitiveTypeHints": "Primitive Map-Schlüssel-Typhinweise ausblenden",
+        "hideMapKeyPrimitiveTypeHintsDesc": "Typhinweise für primitive Map-Schlüssel ausblenden (Text, Integer, Boolean)",
+        "circularReference": "[Zirkuläre Referenz]",
+        "doubleClickToEdit": "Zum Bearbeiten doppelklicken",
+        "keyType": "Schlüsseltyp",
+        "pointer": "Pointer"
+    },
+    "comhub": {
+        "advancedMode": "Erweiterter Modus",
+        "groupByEndpoint": "Nach Endpunkt gruppieren",
+        "searchPlaceholder": "Suchen (z. B. @beispiel)"
     }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -113,5 +113,46 @@
         "jsVersion": "JS Version",
         "endpoint": "Endpoint",
         "activeFeatures": "Active Features"
+    },
+    "endpoint": {
+        "fingerprint": "Fingerprint",
+        "publicInterfaces": "Public Interfaces",
+        "noPublicInterfaces": "No public interfaces exposed by this endpoint.",
+        "channel": "Channel",
+        "direction": "Direction",
+        "maxBandwidth": "Max Bandwidth",
+        "waitingForSockets": "Waiting for socket connections…",
+        "profile": "Profile",
+        "documentation": "Documentation",
+        "pointerView": "Pointer View",
+        "noPointersLoaded": "No pointers currently loaded in the runtime."
+    },
+    "pointer": {
+        "displayPreferences": "Display Preferences",
+        "filterByType": "Filter by Type",
+        "resetFilters": "Reset Filters",
+        "noPointersAvailable": "No pointers available",
+        "noPointersMatchFilters": "No pointers match selected filters",
+        "clickToJump": "Click to jump to definition",
+        "customizeDisplay": "Customize how pointers are displayed",
+        "fullPointerIds": "Full Pointer IDs",
+        "fullPointerIdsDesc": "Show complete pointer identifiers instead of shortened versions",
+        "typeHints": "Type Hints",
+        "typeHintsDesc": "Display type annotations for values",
+        "arrayIndicesKeys": "Array Indices & Keys",
+        "arrayIndicesKeysDesc": "Show array indices and object keys",
+        "hidePrimitiveTypeHints": "Hide Primitive Type Hints",
+        "hidePrimitiveTypeHintsDesc": "Hide type hints for integers, booleans, and text (show for maps/arrays)",
+        "hideMapKeyPrimitiveTypeHints": "Hide Map Key Primitive Type Hints",
+        "hideMapKeyPrimitiveTypeHintsDesc": "Hide type hints for primitive map keys (text, integer, boolean)",
+        "circularReference": "[Circular Reference]",
+        "doubleClickToEdit": "Double-click to edit",
+        "keyType": "Key Type",
+        "pointer": "Pointer"
+    },
+    "comhub": {
+        "advancedMode": "Advanced Mode",
+        "groupByEndpoint": "Group by Endpoint",
+        "searchPlaceholder": "Search (e.g. @example)"
     }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -85,7 +85,7 @@
         "notSigned": "Not signed"
     },
     "trace": {
-        "endpoint": "@endpoint",
+        "endpoint": "\\@endpoint",
         "timeout": "Timeout (ms)",
         "trace": "Trace",
         "tracing": "Tracing...",
@@ -153,6 +153,6 @@
     "comhub": {
         "advancedMode": "Advanced Mode",
         "groupByEndpoint": "Group by Endpoint",
-        "searchPlaceholder": "Search (e.g. @example)"
+        "searchPlaceholder": "Search (e.g. \\@example)"
     }
 }

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -113,5 +113,46 @@
         "jsVersion": "JS संस्करण",
         "endpoint": "एंडपॉइंट",
         "activeFeatures": "सक्रिय सुविधाएँ"
+    },
+    "endpoint": {
+        "fingerprint": "फिंगरप्रिंट",
+        "publicInterfaces": "सार्वजनिक इंटरफ़ेस",
+        "noPublicInterfaces": "इस एंडपॉइंट द्वारा कोई सार्वजनिक इंटरफ़ेस प्रकट नहीं किया गया।",
+        "channel": "चैनल",
+        "direction": "दिशा",
+        "maxBandwidth": "अधिकतम बैंडविड्थ",
+        "waitingForSockets": "सॉकेट कनेक्शन की प्रतीक्षा…",
+        "profile": "प्रोफ़ाइल",
+        "documentation": "दस्तावेज़ीकरण",
+        "pointerView": "पॉइंटर दृश्य",
+        "noPointersLoaded": "वर्तमान में रनटाइम में कोई पॉइंटर लोड नहीं है।"
+    },
+    "pointer": {
+        "displayPreferences": "प्रदर्शन प्राथमिकताएँ",
+        "filterByType": "प्रकार के अनुसार फ़िल्टर करें",
+        "resetFilters": "फ़िल्टर रीसेट करें",
+        "noPointersAvailable": "कोई पॉइंटर उपलब्ध नहीं",
+        "noPointersMatchFilters": "चयनित फ़िल्टर से मेल खाने वाले कोई पॉइंटर नहीं",
+        "clickToJump": "परिभाषा पर जाने के लिए क्लिक करें",
+        "customizeDisplay": "पॉइंटर कैसे प्रदर्शित होंगे, अनुकूलित करें",
+        "fullPointerIds": "पूर्ण पॉइंटर आईडी",
+        "fullPointerIdsDesc": "संक्षिप्त संस्करणों के बजाय पूर्ण पॉइंटर पहचानकर्ता दिखाएं",
+        "typeHints": "प्रकार संकेत",
+        "typeHintsDesc": "मानों के लिए प्रकार एनोटेशन प्रदर्शित करें",
+        "arrayIndicesKeys": "ऐरे इंडेक्स और कुंजियाँ",
+        "arrayIndicesKeysDesc": "ऐरे इंडेक्स और ऑब्जेक्ट कुंजियाँ दिखाएं",
+        "hidePrimitiveTypeHints": "आदिम प्रकार संकेत छिपाएं",
+        "hidePrimitiveTypeHintsDesc": "इंटीजर, बूलियन और टेक्स्ट के लिए प्रकार संकेत छिपाएं (मैप/ऐरे के लिए दिखाएं)",
+        "hideMapKeyPrimitiveTypeHints": "मैप कुंजी आदिम प्रकार संकेत छिपाएं",
+        "hideMapKeyPrimitiveTypeHintsDesc": "आदिम मैप कुंजियों के लिए प्रकार संकेत छिपाएं (टेक्स्ट, इंटीजर, बूलियन)",
+        "circularReference": "[चक्रीय संदर्भ]",
+        "doubleClickToEdit": "संपादित करने के लिए डबल-क्लिक करें",
+        "keyType": "कुंजी प्रकार",
+        "pointer": "पॉइंटर"
+    },
+    "comhub": {
+        "advancedMode": "उन्नत मोड",
+        "groupByEndpoint": "एंडपॉइंट के अनुसार समूहित करें",
+        "searchPlaceholder": "खोजें (जैसे @उदाहरण)"
     }
 }

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -85,7 +85,7 @@
         "notSigned": "अहस्ताक्षरित"
     },
     "trace": {
-        "endpoint": "@एंडपॉइंट",
+        "endpoint": "\\@एंडपॉइंट",
         "timeout": "टाइमआउट (ms)",
         "trace": "ट्रेस",
         "tracing": "ट्रेस कर रहा है...",
@@ -153,6 +153,6 @@
     "comhub": {
         "advancedMode": "उन्नत मोड",
         "groupByEndpoint": "एंडपॉइंट के अनुसार समूहित करें",
-        "searchPlaceholder": "खोजें (जैसे @उदाहरण)"
+        "searchPlaceholder": "खोजें (जैसे \\@उदाहरण)"
     }
 }


### PR DESCRIPTION
Translates endpoint views (Fingerprint, Interfaces, Pointers, View), 
pointer views (PointerView, PointerPreferences, PointerTreeItem, 
PointerRefInline), and ComHub overview.

New namespaces: endpoint, pointer, comhub.
New common keys: download, unavailable, type, reset, searchPlaceholder, unlimited.

Removed redundant endpoint.type in favor of common.type.

Tested locale switching via localStorage in dev- German renders 
correctly across all touched views.