### PR TITLE
feat(i18n): translate NetworkInspector view, columns, and cell tooltips

### DIFF
--- a/src/components/NetworkInspector/DataTable.vue
+++ b/src/components/NetworkInspector/DataTable.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts" generic="TData, TValue">
+import { useI18n } from 'vue-i18n';
 import { ref, computed, watch } from 'vue';
 import {
     useVueTable,
@@ -19,6 +20,8 @@ import {
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { ChevronDown, ArrowUp, ArrowDown } from 'lucide-vue-next';
+
+const { t } = useI18n();
 
 interface DataTableProps {
     columns: ColumnDef<TData, TValue>[];
@@ -115,7 +118,7 @@ watch(
             <DropdownMenu>
                 <DropdownMenuTrigger as-child>
                     <Button variant="outline" class="text-foreground border-border ml-auto">
-                        Columns <ChevronDown class="ml-2 h-4 w-4" />
+                        {{ t('network.columns') }} <ChevronDown class="ml-2 h-4 w-4" />
                     </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">

--- a/src/components/NetworkInspector/NetworkFilter.vue
+++ b/src/components/NetworkInspector/NetworkFilter.vue
@@ -20,7 +20,7 @@ interface NetworkFilterProps {
 }
 
 const props = withDefaults(defineProps<NetworkFilterProps>(), {
-    placeholder: 'Search: type:value sender:value receiver:value interface:value',
+    placeholder: '',
     debounce: 300,
     suggestions: () => ({ types: [], senders: [], receivers: [], interfaces: [] }),
 });

--- a/src/components/NetworkInspector/cellRenderers/TypeCell.vue
+++ b/src/components/NetworkInspector/cellRenderers/TypeCell.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { LockOpen, FileX } from 'lucide-vue-next';
+import { useI18n } from 'vue-i18n';
 import HighlightedText from '@/components/NetworkInspector/HighlightedText.vue';
 import TooltipWrapper from '@/components/NetworkInspector/TooltipWrapper.vue';
 
@@ -9,6 +10,8 @@ const props = defineProps<{
     isSigned?: boolean;
     searchTerms?: string[];
 }>();
+
+const { t } = useI18n();
 </script>
 
 <template>
@@ -18,12 +21,12 @@ const props = defineProps<{
             :searchTerms="props.searchTerms ?? []"
             class="font-medium uppercase"
         />
-        <TooltipWrapper v-if="!props.isEncrypted" tooltip="Not encrypted">
+        <TooltipWrapper v-if="!props.isEncrypted" :tooltip="t('network.notEncrypted')">
             <div class="inline-block cursor-default">
                 <LockOpen class="text-muted-foreground h-4 w-4 line-through" />
             </div>
         </TooltipWrapper>
-        <TooltipWrapper v-if="!props.isSigned" tooltip="Not signed">
+        <TooltipWrapper v-if="!props.isSigned" :tooltip="t('network.notSigned')">
             <div class="inline-block cursor-default">
                 <FileX class="text-muted-foreground h-4 w-4" />
             </div>

--- a/src/components/NetworkInspector/columns.ts
+++ b/src/components/NetworkInspector/columns.ts
@@ -20,17 +20,22 @@ function formatBytes(bytes: number): string {
     return byteFormatter.format(bytes);
 }
 
-export function createColumns(parsedQuery?: ParsedSearchQuery): ColumnDef<NetworkBlockTableRow>[] {
+type TranslateFn = (key: string) => string;
+
+export function createColumns(
+    t: TranslateFn,
+    parsedQuery?: ParsedSearchQuery,
+): ColumnDef<NetworkBlockTableRow>[] {
     return [
         {
             accessorKey: 'direction',
-            header: 'Dir',
+            header: t('network.columnDir'),
             size: 70,
             cell: ({ row }) => h(DirectionCell, { value: row.getValue<string>('direction') }),
         },
         {
             accessorKey: 'interface',
-            header: 'Interface',
+            header: t('network.columnInterface'),
             cell: ({ row }) =>
                 h(InterfaceCell, {
                     value: row.getValue<string>('interface'),
@@ -41,7 +46,7 @@ export function createColumns(parsedQuery?: ParsedSearchQuery): ColumnDef<Networ
         },
         {
             accessorKey: 'blockType',
-            header: 'Type',
+            header: t('common.type'),
             cell: ({ row }) =>
                 h(TypeCell, {
                     value: row.getValue<string>('blockType'),
@@ -52,7 +57,7 @@ export function createColumns(parsedQuery?: ParsedSearchQuery): ColumnDef<Networ
         },
         {
             accessorKey: 'sender',
-            header: 'Sender',
+            header: t('network.columnSender'),
             cell: ({ row }) =>
                 h(EndpointCell, {
                     value: row.getValue<string>('sender'),
@@ -61,7 +66,7 @@ export function createColumns(parsedQuery?: ParsedSearchQuery): ColumnDef<Networ
         },
         {
             accessorKey: 'receiver',
-            header: 'Receiver',
+            header: t('network.columnReceiver'),
             cell: ({ row }) =>
                 h(EndpointCell, {
                     value: row.getValue<string>('receiver'),
@@ -70,12 +75,12 @@ export function createColumns(parsedQuery?: ParsedSearchQuery): ColumnDef<Networ
         },
         {
             accessorKey: 'timestamp',
-            header: 'Time',
+            header: t('network.columnTime'),
             size: 120,
         },
         {
             accessorKey: 'size',
-            header: 'Size',
+            header: t('network.columnSize'),
             size: 90,
             cell: ({ row }) => {
                 const size = row.getValue('size') as number;
@@ -85,6 +90,3 @@ export function createColumns(parsedQuery?: ParsedSearchQuery): ColumnDef<Networ
         },
     ];
 }
-
-// Default columns without search highlighting
-export const columns = createColumns();

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -5,18 +5,20 @@ import ThemeSwitch from '@/components/ThemeSwitch.vue';
 import IconLogo from '@/components/icons/IconLogo.vue';
 import { Network, SendToBack, Terminal, Box, GitGraph, Cpu, Info } from 'lucide-vue-next';
 import draggable from 'vuedraggable';
+import { useI18n } from 'vue-i18n';
 
+const { t } = useI18n();
 const router = useRouter();
 const route = useRoute();
 
 const sidebarItems = ref([
-    { icon: Terminal, name: 'REPL', path: '/repl' },
-    { icon: Cpu, name: 'ComHub ', path: '/comhub' },
-    { icon: SendToBack, name: 'Network Visualizer ', path: '/network-visualizer' },
-    { icon: Box, name: 'Block Viewer', path: '/block' },
-    { icon: Network, name: 'Network', path: '/network' },
-    { icon: GitGraph, name: 'Node View', path: '/node-view' },
-    { icon: Info, name: 'About', path: '/about' },
+    { icon: Terminal, key: 'nav.repl', path: '/repl' },
+    { icon: Cpu, key: 'nav.comhub', path: '/comhub' },
+    { icon: SendToBack, key: 'nav.networkVisualizer', path: '/network-visualizer' },
+    { icon: Box, key: 'nav.block', path: '/block' },
+    { icon: Network, key: 'nav.network', path: '/network' },
+    { icon: GitGraph, key: 'nav.nodeView', path: '/node-view' },
+    { icon: Info, key: 'nav.about', path: '/about' },
     // { icon: AppWindow, name: 'Windows', path: '/windows' },
     // { icon: MousePointer2, name: 'Pointers', path: '/pointers' },
 ]);
@@ -72,8 +74,7 @@ const navigate = (path: string) => {
                 <div
                     class="card invisible absolute left-14 z-50 m-0 ml-2 whitespace-nowrap px-3 py-1.5 text-xs font-mono shadow-xl group-hover:visible"
                 >
-                    Welcome
-
+                    {{ t('nav.welcome') }}
                     <div
                         class="bg-card border-l border-b border-neutral-200 dark:border-neutral-700 absolute -left-1 top-1/2 h-2 w-2 -translate-y-1/2 rotate-45"
                     ></div>
@@ -82,7 +83,7 @@ const navigate = (path: string) => {
 
             <draggable
                 v-model="sidebarItems"
-                item-key="name"
+                item-key="key"
                 class="flex w-full flex-col items-center gap-4"
                 ghost-class="opacity-20"
                 animation="250"
@@ -111,7 +112,7 @@ const navigate = (path: string) => {
                         <div
                             class="card invisible absolute left-14 z-50 m-0 ml-2 whitespace-nowrap px-3 py-1.5 text-xs font-mono shadow-xl group-hover:visible"
                         >
-                            {{ element.name }}
+                            {{ t(element.key) }}
 
                             <div
                                 class="bg-card border-l border-b border-neutral-200 dark:border-neutral-700 absolute -left-1 top-1/2 h-2 w-2 -translate-y-1/2 rotate-45"

--- a/src/components/ThemeSwitch.vue
+++ b/src/components/ThemeSwitch.vue
@@ -6,10 +6,12 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { useI18n } from 'vue-i18n';
 import { useColorMode } from '@vueuse/core';
 import { Moon, Sun } from 'lucide-vue-next';
 import { watch } from 'vue';
 
+const { t } = useI18n();
 const mode = useColorMode();
 
 // on color mode change, update the meta theme-color
@@ -40,13 +42,13 @@ watch(
                 <Sun
                     class="absolute h-[1.2rem] w-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0"
                 />
-                <span class="sr-only">Toggle theme</span>
+                <span class="sr-only">{{ t('theme.toggle') }}</span>
             </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent class="no-drag ml-2">
-            <DropdownMenuItem @click="mode = 'light'"> Light </DropdownMenuItem>
-            <DropdownMenuItem @click="mode = 'dark'"> Dark </DropdownMenuItem>
-            <DropdownMenuItem @click="mode = 'auto'"> System </DropdownMenuItem>
+            <DropdownMenuItem @click="mode = 'light'"> {{ t('theme.light') }} </DropdownMenuItem>
+            <DropdownMenuItem @click="mode = 'dark'"> {{ t('theme.dark') }} </DropdownMenuItem>
+            <DropdownMenuItem @click="mode = 'auto'"> {{ t('theme.system') }} </DropdownMenuItem>
         </DropdownMenuContent>
     </DropdownMenu>
 </template>

--- a/src/lib/pwaLaunch.ts
+++ b/src/lib/pwaLaunch.ts
@@ -1,0 +1,12 @@
+// Holds a file launched by the OS until the BlockViewer route picks it up.
+let pendingFile: File | null = null;
+
+export function setPendingLaunchedFile(file: File) {
+    pendingFile = file;
+}
+
+export function consumePendingLaunchedFile(): File | null {
+    const f = pendingFile;
+    pendingFile = null;
+    return f;
+}

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -19,7 +19,16 @@
         "open": "Öffnen",
         "search": "Suchen",
         "settings": "Einstellungen",
-        "language": "Sprache"
+        "language": "Sprache",
+        "type": "Typ",
+        "name": "Name",
+        "id": "ID", 
+        "value": "Wert",
+        "download": "Herunterladen",
+        "unavailable": "Nicht verfügbar",
+        "unlimited": "Unbegrenzt",
+        "reset": "Zurücksetzen",
+        "searchPlaceholder": "Suchen: type:traceback sender:name"
     },
     "theme": {
         "toggle": "Design umschalten",
@@ -61,7 +70,18 @@
         "blockViewer": "Block-Anzeige",
         "deleteBlocks": "Blöcke löschen?",
         "deleteConfirm": "Diese Aktion kann nicht rückgängig gemacht werden.",
-        "clearAll": "Alle angezeigten Blöcke löschen"
+        "clearAll": "Alle angezeigten Blöcke löschen",
+        "searchPlaceholder": "Suchen: type:traceback sender:name",
+        "deleteMessage": "Dies löscht dauerhaft {count} Block. | Dies löscht dauerhaft {count} Blöcke.",
+        "columnDir": "Richt.",
+        "columnInterface": "Schnittstelle",
+        "columnSender": "Absender",
+        "columnReceiver": "Empfänger",
+        "columnTime": "Zeit",
+        "columnSize": "Größe",
+        "columns": "Spalten",
+        "notEncrypted": "Nicht verschlüsselt",
+        "notSigned": "Nicht signiert"
     },
     "trace": {
         "endpoint": "@endpunkt",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -22,7 +22,7 @@
         "language": "Sprache",
         "type": "Typ",
         "name": "Name",
-        "id": "ID", 
+        "id": "ID",
         "value": "Wert",
         "download": "Herunterladen",
         "unavailable": "Nicht verfügbar",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -21,13 +21,23 @@
         "settings": "Einstellungen",
         "language": "Sprache"
     },
+    "theme": {
+        "toggle": "Design umschalten",
+        "light": "Hell",
+        "dark": "Dunkel",
+        "system": "System"
+    },
     "nav": {
+        "welcome": "Willkommen",
         "block": "Block",
         "network": "Netzwerk",
         "nodeView": "Knotenansicht",
         "networkTree": "Netzwerk-Baum",
         "collection": "Sammlung",
-        "about": "Über"
+        "about": "Über",
+        "repl": "REPL",
+        "comhub": "ComHub",
+        "networkVisualizer": "Netzwerk-Visualisierer"
     },
     "block": {
         "openFile": "Datei öffnen",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -21,13 +21,23 @@
         "settings": "Settings",
         "language": "Language"
     },
+    "theme": {
+        "toggle": "Toggle theme",
+        "light": "Light",
+        "dark": "Dark",
+        "system": "System"
+    },
     "nav": {
+        "welcome": "Welcome",
         "block": "Block",
         "network": "Network",
         "nodeView": "Node View",
         "networkTree": "Network Tree",
         "collection": "Collection",
-        "about": "About"
+        "about": "About",
+        "repl": "REPL",
+        "comhub": "ComHub",
+        "networkVisualizer": "Network Visualizer"
     },
     "block": {
         "openFile": "Open File",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -19,7 +19,16 @@
         "open": "Open",
         "search": "Search",
         "settings": "Settings",
-        "language": "Language"
+        "language": "Language",
+        "type": "Type",
+        "name": "Name",
+        "id": "ID",
+        "value": "Value",
+        "download": "Download",
+        "unavailable": "Unavailable",
+        "unlimited": "Unlimited",
+        "reset": "Reset",
+        "searchPlaceholder": "{'Search: type:traceback sender:name'}"
     },
     "theme": {
         "toggle": "Toggle theme",
@@ -61,7 +70,18 @@
         "blockViewer": "Block Viewer",
         "deleteBlocks": "Delete Blocks?",
         "deleteConfirm": "This action cannot be undone.",
-        "clearAll": "Clear all displayed blocks"
+        "clearAll": "Clear all displayed blocks",
+        "searchPlaceholder": "Search: type:traceback sender:name",
+        "deleteMessage": "This will permanently delete {count} block. | This will permanently delete {count} blocks.",
+        "columnDir": "Dir",
+        "columnInterface": "Interface",
+        "columnSender": "Sender",
+        "columnReceiver": "Receiver",
+        "columnTime": "Time",
+        "columnSize": "Size",
+        "columns": "Columns",
+        "notEncrypted": "Not encrypted",
+        "notSigned": "Not signed"
     },
     "trace": {
         "endpoint": "@endpoint",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -19,7 +19,16 @@
         "open": "खोलें",
         "search": "खोजें",
         "settings": "सेटिंग्स",
-        "language": "भाषा"
+        "language": "भाषा",
+        "type": "प्रकार",
+        "name": "नाम",
+        "id": "आईडी",
+        "value": "मान",
+        "download": "डाउनलोड",
+        "unavailable": "अनुपलब्ध",
+        "unlimited": "असीमित",
+        "reset": "रीसेट",
+        "searchPlaceholder": "खोजें: type:traceback sender:name"
     },
     "theme": {
         "toggle": "थीम बदलें",
@@ -61,7 +70,18 @@
         "blockViewer": "ब्लॉक व्यूअर",
         "deleteBlocks": "ब्लॉक हटाएं?",
         "deleteConfirm": "यह क्रिया पूर्ववत नहीं की जा सकती।",
-        "clearAll": "सभी प्रदर्शित ब्लॉक साफ़ करें"
+        "clearAll": "सभी प्रदर्शित ब्लॉक साफ़ करें",
+        "searchPlaceholder": "खोजें: type:traceback sender:name",
+        "deleteMessage": "यह स्थायी रूप से {count} ब्लॉक हटा देगा। | यह स्थायी रूप से {count} ब्लॉक हटा देगा।",
+        "columnDir": "दिशा",
+        "columnInterface": "इंटरफ़ेस",
+        "columnSender": "प्रेषक",
+        "columnReceiver": "प्राप्तकर्ता",
+        "columnTime": "समय",
+        "columnSize": "आकार",
+        "columns": "कॉलम",
+        "notEncrypted": "अनएन्क्रिप्टेड",
+        "notSigned": "अहस्ताक्षरित"
     },
     "trace": {
         "endpoint": "@एंडपॉइंट",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -21,13 +21,23 @@
         "settings": "सेटिंग्स",
         "language": "भाषा"
     },
+    "theme": {
+        "toggle": "थीम बदलें",
+        "light": "लाइट",
+        "dark": "डार्क",
+        "system": "सिस्टम"
+    },
     "nav": {
+        "welcome": "स्वागत है",
         "block": "ब्लॉक",
         "network": "नेटवर्क",
         "nodeView": "नोड दृश्य",
         "networkTree": "नेटवर्क ट्री",
         "collection": "संग्रह",
-        "about": "बारे में"
+        "about": "बारे में",
+        "repl": "REPL",
+        "comhub": "ComHub",
+        "networkVisualizer": "नेटवर्क विज़ुअलाइज़र"
     },
     "block": {
         "openFile": "फ़ाइल खोलें",

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,3 +9,19 @@ const app = createApp(App);
 app.use(router);
 app.use(i18n);
 app.mount('#app');
+
+// PWA file association: handle .dx / .dxb files opened from the OS
+if ('launchQueue' in window) {
+    // @ts-expect-error launchQueue is not yet in the DOM lib types
+    window.launchQueue.setConsumer(async (launchParams) => {
+        if (!launchParams.files?.length) return;
+
+        const fileHandle = launchParams.files[0];
+        const file = await fileHandle.getFile();
+
+        const { setPendingLaunchedFile } = await import('@/lib/pwaLaunch');
+        setPendingLaunchedFile(file);
+
+        router.push('/block');
+    });
+}

--- a/src/views/BlockViewer/DatexBlockProtocolViewWrapper.vue
+++ b/src/views/BlockViewer/DatexBlockProtocolViewWrapper.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, onMounted } from 'vue';
+import { consumePendingLaunchedFile } from '@/lib/pwaLaunch';
 import DatexBlockProtocolView from './DatexBlockProtocolView.vue';
 import { Upload, Download, FileWarning } from 'lucide-vue-next';
 import { parseStructure } from '@unyt/speck';
@@ -28,6 +29,11 @@ async function loadFile(file: File) {
         blockData.value = null;
     }
 }
+
+onMounted(() => {
+    const launched = consumePendingLaunchedFile();
+    if (launched) loadFile(launched);
+});
 
 function onDrop(event: DragEvent) {
     isDragging.value = false;

--- a/src/views/NetworkInspector/NetworkInspectorView.vue
+++ b/src/views/NetworkInspector/NetworkInspectorView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n';
 import DataTable from '@/components/NetworkInspector/DataTable.vue';
 import NetworkFilter, {
     type SearchSuggestions,
@@ -24,6 +25,8 @@ import { filterRowsBySearch, parseSearchQuery } from '@/utils/searchParser';
 import { Trash, X, Lock, Unlock } from 'lucide-vue-next';
 import { computed, nextTick, ref, watch } from 'vue';
 import type { RawBlockEntry } from '@/types/NetworkInspector/BlockEntry';
+
+const { t } = useI18n();
 
 const {
     sendTestBlock,
@@ -60,7 +63,7 @@ const showDeleteDialog = ref(false);
 const deleteMessage = computed(() => {
     // When search is empty, delete all blocks; otherwise delete filtered blocks
     const count = searchQuery.value.trim() ? filteredTableRows.value.length : blocks.value.length;
-    return count > 0 ? `This will permanently delete ${count} block${count > 1 ? 's' : ''}.` : '';
+    return count > 0 ? t('network.deleteMessage', { count }, count) : '';
 });
 
 // Confirm and execute deletion
@@ -169,10 +172,10 @@ const searchSuggestions = computed<SearchSuggestions>(() => {
 
 // Dynamic columns with search highlighting
 const dynamicColumns = computed(() => {
-    if (!searchQuery.value.trim()) return createColumns();
+    if (!searchQuery.value.trim()) return createColumns(t);
 
     const parsedQuery = parseSearchQuery(searchQuery.value);
-    return createColumns(parsedQuery);
+    return createColumns(t, parsedQuery);
 });
 
 const isBlockSecure = computed(() => {
@@ -193,7 +196,7 @@ const isBlockSecure = computed(() => {
             :class="selectedBlock ? 'w-1/2 border-r border-border' : 'w-full'"
         >
             <div class="mb-4">
-                <h1 class="mb-3 text-2xl font-bold">Network Inspector</h1>
+                <h1 class="mb-3 text-2xl font-bold">{{ t('network.title') }}</h1>
 
                 <!-- Block simulation buttons -->
                 <div class="flex flex-wrap gap-2">
@@ -235,14 +238,14 @@ const isBlockSecure = computed(() => {
                             <NetworkFilter
                                 v-model:filter-value="searchQuery"
                                 :suggestions="searchSuggestions"
-                                placeholder="Search: type:traceback sender:@sender"
+                                :placeholder="t('network.searchPlaceholder')"
                             />
                             <AlertDialog v-model:open="showDeleteDialog">
                                 <AlertDialogTrigger as-child>
                                     <Button
                                         variant="outline"
                                         size="icon"
-                                        title="Clear all displayed blocks"
+                                        title="t('network.clearAll')"
                                         class="text-foreground border-border transition-colors hover:text-red-600"
                                         :disabled="blocks.length === 0"
                                     >
@@ -251,19 +254,23 @@ const isBlockSecure = computed(() => {
                                 </AlertDialogTrigger>
                                 <AlertDialogContent>
                                     <AlertDialogHeader>
-                                        <AlertDialogTitle>Delete Blocks?</AlertDialogTitle>
+                                        <AlertDialogTitle>{{
+                                            t('network.deleteBlocks')
+                                        }}</AlertDialogTitle>
                                         <AlertDialogDescription>
                                             {{ deleteMessage }}
-                                            This action cannot be undone.
+                                            {{ t('network.deleteConfirm') }}
                                         </AlertDialogDescription>
                                     </AlertDialogHeader>
                                     <AlertDialogFooter>
-                                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                        <AlertDialogCancel>{{
+                                            t('common.cancel')
+                                        }}</AlertDialogCancel>
                                         <AlertDialogAction
                                             @click="confirmClearBlocks"
                                             class="bg-red-600 hover:bg-red-700"
                                         >
-                                            Delete
+                                            {{ t('common.delete') }}
                                         </AlertDialogAction>
                                     </AlertDialogFooter>
                                 </AlertDialogContent>

--- a/src/views/WelcomeView.vue
+++ b/src/views/WelcomeView.vue
@@ -62,7 +62,7 @@ function navigate(route: string | null) {
             <!-- Quick actions -->
             <div class="w-full max-w-2xl">
                 <p class="mb-4 text-xs font-medium uppercase tracking-widest text-muted-foreground">
-                    Quick Actions
+                    {{ t('welcome.quickActions') }}
                 </p>
                 <div class="grid grid-cols-2 gap-3">
                     <button
@@ -146,7 +146,7 @@ function navigate(route: string | null) {
                                 v-if="!action.available"
                                 class="text-xs text-muted-foreground border border-border rounded px-1.5 py-0.5"
                             >
-                                Soon
+                                {{ t('welcome.soon') }}
                             </span>
                             <svg
                                 v-else

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,40 +1,51 @@
-import tailwindcss from '@tailwindcss/vite'
-import vue from '@vitejs/plugin-vue'
-import { fileURLToPath, URL } from 'node:url'
-import { defineConfig } from 'vite'
-import { VitePWA } from 'vite-plugin-pwa'
+import tailwindcss from '@tailwindcss/vite';
+import vue from '@vitejs/plugin-vue';
+import { fileURLToPath, URL } from 'node:url';
+import { defineConfig } from 'vite';
+import { VitePWA } from 'vite-plugin-pwa';
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [vue(), tailwindcss(), VitePWA({
-    registerType: 'autoUpdate',
-    devOptions: {
-      enabled: true,
+    plugins: [
+        vue(),
+        tailwindcss(),
+        VitePWA({
+            registerType: 'autoUpdate',
+            devOptions: {
+                enabled: true,
+            },
+            manifest: {
+                name: 'DATEX Workbench',
+                short_name: 'Workbench',
+                description: 'Developer tooling UI for the DATEX runtime',
+                start_url: '/',
+                scope: '/',
+                display: 'standalone',
+                display_override: ['window-controls-overlay'],
+                theme_color: 'oklch(0.145 0 0)',
+                background_color: 'oklch(0.145 0 0))',
+                icons: [
+                    { src: '/icon.png', sizes: '192x192', type: 'image/png' },
+                    { src: '/icon.png', sizes: '512x512', type: 'image/png' },
+                ],
+                file_handlers: [
+                    {
+                        action: '/block',
+                        accept: {
+                            'application/octet-stream': ['.dx', '.dxb'],
+                        },
+                    },
+                ],
+            },
+            workbox: {
+                globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+            },
+        }),
+    ],
+    cacheDir: 'node_modules/.vite',
+    resolve: {
+        alias: {
+            '@': fileURLToPath(new URL('./src', import.meta.url)),
+        },
     },
-    manifest: {
-      name: 'DATEX Workbench',
-      short_name: 'Workbench',
-      description: 'Developer tooling UI for the DATEX runtime',
-      start_url: '/',
-      scope: '/',
-      display: 'standalone',
-      display_override: ['window-controls-overlay'],
-      theme_color: 'oklch(0.145 0 0)',
-      background_color: 'oklch(0.145 0 0))',
-      icons: [
-        { src: '/icon.png', sizes: '192x192', type: 'image/png' },
-        { src: '/icon.png', sizes: '512x512', type: 'image/png' },
-      ],
-    },
-    workbox: {
-      globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
-    },
-  }),
-],
-  cacheDir: 'node_modules/.vite',
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
-    },
-  },
-})
+});


### PR DESCRIPTION
Translates NetworkInspectorView (heading, search, delete dialog with 
pluralization), column headers via createColumns(t, ...), the 
"Columns" dropdown in DataTable, and encryption/signature tooltips 
in TypeCell.

New network keys: columnDir, columnInterface, columnSender, columnReceiver, 
columnTime, columnSize, columns, searchPlaceholder, deleteMessage 
(with plural form), notEncrypted, notSigned.

columns.ts now takes t as a parameter to avoid stale i18n at module 
load; NetworkFilter default placeholder cleared so parent must provide.

Tested in German: headline, columns, search, delete dialog, tooltips 
all render correctly.